### PR TITLE
Add snapshot testing for article HTML cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,9 @@ pointer-io-rssfeed = "pointer_io_rssfeed:main"
 [dependency-groups]
 dev = [
   "mypy",
+  "pytest>=9.0.3",
   "ruff",
+  "syrupy>=5.2.0",
   "types-beautifulsoup4",
 ]
 
@@ -31,6 +33,10 @@ build-backend = "uv_build"
 
 [tool.mypy]
 strict = true
+
+[tool.pytest.ini_options]
+addopts = ["--import-mode=importlib"]
+testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 120
@@ -45,4 +51,10 @@ ignore = [
   "FIX002",
   "TD002",
   "TD003",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+  "INP001",  # tests/ doesn't need __init__.py
+  "PLR2004",  # magic values are fine in tests
 ]

--- a/src/pointer_io_rssfeed/__init__.py
+++ b/src/pointer_io_rssfeed/__init__.py
@@ -11,7 +11,7 @@ import click
 import httpx
 import trio
 
-from pointer_io_rssfeed import rss
+from pointer_io_rssfeed import cleanup, rss
 
 _BASE_URL = httpx.URL("https://www.pointer.io/")
 _LOGGER = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ async def _article_tag_to_rss_item(
     )
 
     html = await _fetch_archive_html(client=client, href=href, cache_dir=cache_dir)
-    description = _html_to_description(html)
+    description = cleanup.html_to_description(html)
 
     return rss.Item(
         title=h2.text.strip(),
@@ -84,13 +84,9 @@ async def _fetch_archive_html(*, client: httpx.AsyncClient, href: str, cache_dir
     return html
 
 
-def _html_to_description(html: str) -> str:
-    soup = bs4.BeautifulSoup(html, features="html.parser")
-
-    # TODO: remove stuff after "Notable links"
-    # TODO: remove ads
-    # TODO: remove header eg: "Friday 5th December issue is presented by Augment Code"
-    return str(soup.find("tr", id="content-blocks"))
+def _item_pub_date(item: rss.Item) -> datetime.datetime:
+    assert item.pub_date is not None
+    return item.pub_date
 
 
 @click.command(
@@ -176,7 +172,7 @@ def main(
             ),
             description="Essential Reading For Engineering Leaders",
             last_build_date=datetime.datetime.now(tz=datetime.UTC),
-            items=sorted(rss_items, key=lambda item: item.pub_date),
+            items=sorted(rss_items, key=_item_pub_date),
         )
 
         # output RSS Feed to stdout

--- a/src/pointer_io_rssfeed/cleanup.py
+++ b/src/pointer_io_rssfeed/cleanup.py
@@ -1,0 +1,10 @@
+import bs4
+
+
+def html_to_description(html: str) -> str:
+    soup = bs4.BeautifulSoup(html, features="html.parser")
+
+    # TODO: remove stuff after "Notable links"
+    # TODO: remove ads
+    # TODO: remove header eg: "Friday 5th December issue is presented by Augment Code"
+    return str(soup.find("tr", id="content-blocks"))

--- a/src/pointer_io_rssfeed/rss.py
+++ b/src/pointer_io_rssfeed/rss.py
@@ -1,9 +1,11 @@
-import datetime
 import email.utils
 import xml.etree.ElementTree as ET
-from typing import NewType, Protocol
+from typing import TYPE_CHECKING, NewType, Protocol
 
 import attrs
+
+if TYPE_CHECKING:
+    import datetime
 
 URL = NewType("URL", str)
 

--- a/tests/__snapshots__/test_cleanup.ambr
+++ b/tests/__snapshots__/test_cleanup.ambr
@@ -1,0 +1,1768 @@
+# serializer version: 1
+# name: test_html_to_description[01b4cdda41.html]
+  '''
+  None
+  
+  '''
+# ---
+# name: test_html_to_description[ee9c973edf.html]
+  '''
+  None
+  
+  '''
+# ---
+# name: test_html_to_description[post_37528c1f-7f9d-43b2-aff4-989d860adb3f.html]
+  '''
+  <tr id="content-blocks">
+   <td align="center" class="email-card-body" style="padding-bottom:px;" valign="top">
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="none" width="100%">
+     <tr>
+      <td align="center" class="dd" style="padding:0px 10px;text-align:center;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        Tuesday 5th May’s issue is presented by Atono
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="padding-bottom:10px;padding-left:10px;padding-right:10px;padding-top:10px; " valign="top">
+       <table border="0" cellpadding="0" cellspacing="0" role="none" style="margin:0 auto 0 auto;">
+        <tr>
+         <td align="center" style="width:455px;" valign="top">
+          <a href="https://atono.io/lp/context-gap-report?utm_campaign=274400984-2026%20%E2%80%93%20Asset%20%E2%80%93%20Context%20Gap%20Industry%20Report&amp;utm_source=pointer_io_newsletter&amp;utm_medium=sponsored_ad&amp;utm_content=context_gap_report&amp;aid=recTESLn3iI6Hr7sT&amp;_bhlid=561c9a139950a220f0567060f37e1fa46c8d9a64" rel="noopener noreferrer nofollow" style="text-decoration:none;" target="_blank">
+           <img alt="" border="0" height="auto" src="https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/43b4116c-3f03-43e4-bd35-e3649f56b9ce/unnamed.png?t=1777923440" style="display:block;width:100%;border-radius:0px 0px 0px 0px;border-style:solid;border-width:0px 0px 0px 0px;box-sizing:border-box;border-color:#E5E7EB;" width="455"/>
+          </a>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="what-350-engineers-revealed-about-a" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;" valign="top">
+       <h2 style="color:#000000;font-weight:Bold;mso-line-height-alt:150.0%;">
+        <a class="link" href="https://atono.io/lp/context-gap-report?utm_campaign=274400984-2026%20%E2%80%93%20Asset%20%E2%80%93%20Context%20Gap%20Industry%20Report&amp;utm_source=pointer_io_newsletter&amp;utm_medium=sponsored_ad&amp;utm_content=context_gap_report&amp;aid=recabWKgk7TJLasPb&amp;_bhlid=d7497fa74819a9db1729f1216f729221a9a7d2ab" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          What 350 Engineers Revealed About AI Development Bottlenecks
+         </span>
+        </a>
+       </h2>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        AI is accelerating development teams, but overall velocity hasn't really improved. The bottleneck isn't at the code layer. It's upstream, in the
+        <a class="link" href="https://atono.io/lp/context-gap-report?utm_campaign=274400984-2026%20%E2%80%93%20Asset%20%E2%80%93%20Context%20Gap%20Industry%20Report&amp;utm_source=pointer_io_newsletter&amp;utm_medium=sponsored_ad&amp;utm_content=context_gap_report&amp;aid=recZCaNJDgmkJLyGT&amp;_bhlid=b509ab3e74b2b4c6f266a910298a7487ea57850d" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          gap between what product teams decide and what engineering teams actually receive
+         </span>
+        </a>
+        .
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        Atono's
+        <a class="link" href="https://atono.io/lp/context-gap-report?utm_campaign=274400984-2026%20%E2%80%93%20Asset%20%E2%80%93%20Context%20Gap%20Industry%20Report&amp;utm_source=pointer_io_newsletter&amp;utm_medium=sponsored_ad&amp;utm_content=context_gap_report&amp;aid=recznB3pQBsPT1liL&amp;_bhlid=3d71dd222984628d307eafd6afc58260b87f0d18" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          Context Gap Industry Report
+         </span>
+        </a>
+        shares what they found when they asked 350 engineering professionals where AI product development actually breaks down.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        Inside the report:
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td class="ee" style="padding-bottom:5px;padding-left:15px;padding-right:15px;padding-top:5px;">
+       <div class="edm_outlooklist" style="margin-left:0px;">
+        <ul style="font-weight:normal;list-style-type:disc;margin-bottom:12px !important;margin-top:12px !important;padding:0px 0px 0px 0px;">
+         <li class="listItem ultext">
+          <p style="mso-line-height-alt:150.0%;padding:0px;text-align:left;word-break:break-word;">
+           Why 52% of teams have no shared AI context across developers
+          </p>
+         </li>
+         <li class="listItem ultext">
+          <p style="mso-line-height-alt:150.0%;padding:0px;text-align:left;word-break:break-word;">
+           How unclear requirements drive the majority of engineering rework
+          </p>
+         </li>
+         <li class="listItem ultext">
+          <p style="mso-line-height-alt:150.0%;padding:0px;text-align:left;word-break:break-word;">
+           Why AI at the implementation layer, without clarity at the planning layer, mostly accelerates rework
+          </p>
+         </li>
+         <li class="listItem ultext">
+          <p style="mso-line-height-alt:150.0%;padding:0px;text-align:left;word-break:break-word;">
+           What teams with the least rework are doing differently
+          </p>
+         </li>
+        </ul>
+       </div>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        If you're leading engineering, this report shows you where the real leverage is.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" id="claim-your-075-apy-boost" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:center;" valign="top">
+       <h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;">
+        <a class="link" href="https://atono.io/lp/context-gap-report?utm_campaign=274400984-2026%20%E2%80%93%20Asset%20%E2%80%93%20Context%20Gap%20Industry%20Report&amp;utm_source=pointer_io_newsletter&amp;utm_medium=sponsored_ad&amp;utm_content=context_gap_report&amp;aid=recBbkHZXRHlo4dHw&amp;_bhlid=d4d1a4698b60e142c845d55488676dd83bb2d760" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          Download The Free Report
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="managing-up" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;">
+        <a class="link" href="https://randsinrepose.com/archives/managing-up/?&amp;aid=recDynfeQM5lW6ItW&amp;aid=recaiy3bj93QJElYV&amp;_bhlid=80376fa7e55b923106bf5b8ea585c9c76495b424" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          Managing Up
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Michael Lopp
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : “In this piece, I will explain the projects, people, and political developments you always want to share - no matter what. While I will strive to make this complete, there is one type of development you must always report.”
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="management-communication-managing-u" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          Management Communication ManagingUp
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="ask-for-advice-not-permission" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;">
+        <a class="link" href="https://luminousmen.substack.com/p/be-the-idiot?aid=receSJ0PffNO6cVRJ&amp;_bhlid=33dd4509b617603a9f675cb13e49c3fde670c112" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          Be The Idiot
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Kirill Bobrov
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : “I’ve developed a mental checklist of “stupid” questions that have saved me more times than I can count.” The author shares some of these with the understanding that most engineering failures happen because someone was afraid to look stupid.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="leadership-management" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          Communication CareerGrowth
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="feature-riffing-how-ai-helps-p-ms-r" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;">
+        <a class="link" href="https://atono.io/blog/feature-riffing-ai-refine-product-ideas-before-design?aid=recrNfMD0PMMl1JhL&amp;_bhlid=d56ae17a4875818e1946a7dae11b9a21e0740a52" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          Feature Riffing: How AI Helps PMs Refine Ideas Before Design
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : Better specs = fewer refinement cycles = faster shipping. Most acceptance criteria look solid on paper until engineering starts building. This post shows how product teams are using AI to validate feature logic through interactive mockups—surfacing edge cases and hierarchical complexity before specs reach your team.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <i>
+         Promoted by Atono
+        </i>
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="ai-product" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          AI Product
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="everything-you-need-to-know-about-o" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;">
+        <a class="link" href="https://kimmalonescott.medium.com/fun-feedback-exercises-activities-to-do-with-your-team-67faacccb77c?aid=recPQdX1jVc2EFWyd&amp;_bhlid=c5f01f138fd2dab4c46d471667a51d72c2514fb5" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          Fun Feedback Exercises &amp; Activities To Do With Your Team
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Kim Scott
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : “Engaging your team with fun feedback exercises can help create a culture of open communication and continuous improvement. Here are a few ideas you might find helpful.”
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="leadership-management-career-growth" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          Management Guide Feedback
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="padding:30px 10px 30px 10px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="d" role="none" style="background-color:#101720;border-color:#ffffff;border-radius:10px 10px 10px 10px;border-style:solid;border-width:1px 1px 1px 1px;" width="100%">
+        <tr>
+         <td align="center" class="dd" style="padding:20px 20px 20px 20px;" valign="top">
+          <table align="center" border="0" cellpadding="0" cellspacing="0" role="none" width="100%">
+           <tr>
+            <td align="center" class="i" valign="top">
+             <p style="color:#f3f4f6;font-weight:normal;margin:0px;text-align:center;">
+              “If you hear a voice within you say, ‘You cannot paint,’ then by all means paint and that voice will be silenced.”
+             </p>
+            </td>
+           </tr>
+           <tr>
+            <td height="14" style="line-height:1px;font-size:1px;height:14;">
+            </td>
+           </tr>
+           <tr>
+            <td align="center" class="h" style="color:#ffffff;font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-size:14px;font-weight:normal;padding-bottom:12px;padding-top:12px;" valign="top">
+             — Vincent Van Gogh
+            </td>
+           </tr>
+          </table>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="3-constraints-before-i-build-anythi" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;">
+        <a class="link" href="https://jordanlord.co.uk/blog/3-constraints/?aid=rech8Jz6f2MZAYdxa&amp;_bhlid=5f4befe58bd81af4ab8b9ff4254794504e4cdcab" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          3 Constraints Before I Build Anything
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Jordan Lord
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : “I’ve been a builder for 10 years, and I've built products that went nowhere because they were either too complex or had no identity. These are the constraints that I landed on after making those mistakes.”
+        <span style="font-size:12px;">
+         <i>
+         </i>
+        </span>
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="ai-guide-best-practices" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          AI Guide BestPractices
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="to-make-sl-ms-think-bigger-orchestr" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;">
+        <a class="link" href="https://fandf.co/4tiqz4S?aid=reclPsYQdBrLSfxoa&amp;_bhlid=220f99f8a68893f3d93e00892f8887253385553c" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          To Make SLMs Think Bigger, Orchestration Is The Key
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Nacho Martinez
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : Small language models often fail at multi-step reasoning, but agent-based architectures can bridge the gap. By layering search and control flow over LLM calls, the agent-reasoning framework adds 16 research-backed strategies to any Ollama model with zero code changes.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <i>
+         Promoted by Oracle
+        </i>
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="ai-deep-dive-guide" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          AI DeepDive Guide
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="how-to-run-a-technical-due-diligenc" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;">
+        <a class="link" href="https://makemeacto.substack.com/p/how-to-run-a-technical-due-diligence?aid=recSRVeC737tilDdV&amp;_bhlid=271a2aa9ff7e89beab4e185d43e83f313465a332" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          How to Run a Technical Due Diligence?
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Sergio Visinoni
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : A walkthrough of running a technical due diligence during M&amp;A. Covers what the data room actually is, the four types of deals - brand acquisition, independent operation, full integration, acqui-hire - and what to prioritize in each - from security and compliance to talent assessment to data portability.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="ai-event" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          Leadership Guide Business
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="you-should-make-a-new-programming-l" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;">
+        <a class="link" href="https://philpearl.github.io/post/swissing_a_table/?aid=recOvpZbA7cPVAWrc&amp;_bhlid=de8d72cb3ba6745e8c010c6fa48c91ce8d44ad03" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          Swissing A Table
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Philip Pearl
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : “This year I chose to investigate “Swiss tables”, the new hash table idea behind recent improvements to Go’s maps. Why am I interested in this? I’ve written a number of specialist hash tables, and I wondered if these approaches would lead to any performance improvements.”
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="deep-dive-performance" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          DeepDive Performance
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="the-ai-engineering-stack-we-built-i" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;">
+        <a class="link" href="https://blog.cloudflare.com/internal-ai-engineering-stack/?aid=rec9mevXRn0xFN4du&amp;_bhlid=240459f04a808077699e6a51f06da5755018e09e" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          The AI Engineering Stack We Built Internally - On The Platform We Ship
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Rajesh Bhatia, Scott Roe-Meschke, Ayush Thakur
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : “Eleven months ago, we undertook a major project: to truly integrate AI into our engineering stack. We needed to build the internal MCP servers, access layer, and AI tooling necessary for agents to be useful at Cloudflare. We pulled together engineers from across the company to form a tiger team called iMARS (Internal MCP Agent/Server Rollout Squad). The sustained work landed with the Dev Productivity team, who also own much of our internal tooling including CI/CD, build systems, and automation.”
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="developer-productivity-best-practic" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          AI Infrastructure CaseStudy
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="most-popular-from-last-issue" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;">
+        Most Popular From Last Issue
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         <a class="link" href="https://luminousmen.substack.com/p/drunk-post-things-ive-learned-as?aid=recB1tEgoOXzSQ5z1&amp;_bhlid=eb7ae569da26087da2b02a83253aea6404c960f6" rel="noopener noreferrer nofollow" target="_blank">
+          <span>
+           Drunk Post: Things I’ve Learned As A Senior Engineer
+          </span>
+         </a>
+        </b>
+        -
+        <b>
+        </b>
+        Kirill Bobrov
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="notable-links" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;">
+        Notable Links
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="code-burn-track-token-usage-cost-an" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         <a class="link" href="https://github.com/getagentseal/codeburn?aid=recxPMLHKpZ23VjVV&amp;_bhlid=eaf560db73625c67c132b670d1e8484e983054de" rel="noopener noreferrer nofollow" target="_blank">
+          <span>
+           CodeBurn
+          </span>
+         </a>
+        </b>
+        : Track token usage, cost, and performance.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="flue-agent-harness-framework" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         <a class="link" href="https://github.com/withastro/flue?aid=recyA0O9u9TEQJ4Nm&amp;_bhlid=04e40d905de48b8b8dbfb4196ab754209cb7a974" rel="noopener noreferrer nofollow" target="_blank">
+          <span>
+           Flue
+          </span>
+         </a>
+        </b>
+        : Agent harness framework.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="openhare-a-ipowered-crossplatform-d" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         <a class="link" href="https://github.com/sjjian/openhare?aid=recKVEJgkjrE2dQF9&amp;_bhlid=4cfa653e5675e2bf14f1347a2b41c85f72887686" rel="noopener noreferrer nofollow" target="_blank">
+          <span>
+           Openhare
+          </span>
+         </a>
+        </b>
+        : AI-powered, cross-platform desktop SQL client.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="space-agent-os-agent-that-builds-yo" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         <a class="link" href="https://github.com/agent0ai/space-agent?aid=recVTnIwihmnEa9Ms&amp;_bhlid=a72c63674a9cab042643f437ed88a9cf91332a03" rel="noopener noreferrer nofollow" target="_blank">
+          <span>
+           Space Agent
+          </span>
+         </a>
+        </b>
+        : OS agent that builds your space in the browser.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="super-plane-os-control-plane-for-pl" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         <a class="link" href="https://github.com/superplanehq/superplane?aid=recxZ5rgT3P0sDglh&amp;_bhlid=2a9d2790d5cc7d7856b5b1c30aee40d794f58d89" rel="noopener noreferrer nofollow" target="_blank">
+          <span>
+           SuperPlane
+          </span>
+         </a>
+        </b>
+        : OS control plane for platform engineering.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="e" valign="top">
+       <table align="left" border="0" cellpadding="0" cellspacing="0" role="none">
+        <tr>
+         <td align="left" style="padding:10px 10px 10px;" valign="top">
+          <h3 style="">
+           How did you like this issue of Pointer?
+          </h3>
+          <p style="">
+           1 = Didn't enjoy it all // 5 = Really enjoyed it
+          </p>
+         </td>
+        </tr>
+        <tr>
+         <td align="left" style="padding:0px 10px 10px;" valign="top">
+          <span>
+           <a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=168ea9f2-7130-4ae4-8f04-7bf1bd8780ea&amp;ppid=c84ccdcd-2327-4f80-98e1-604a37e58d41&amp;sid=SUBSCRIBER_ID&amp;_bhlid=8760cc8cee40d6e4b60fa86aee26007ad8416c32">
+            1
+           </a>
+          </span>
+          <span style="">
+           |
+          </span>
+          <span>
+           <a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=9e524ac8-f554-4474-b06d-a0a1b5f9e2d5&amp;ppid=c84ccdcd-2327-4f80-98e1-604a37e58d41&amp;sid=SUBSCRIBER_ID&amp;_bhlid=4b6686c67360b29e6d080c618a9eda99173d0c46">
+            2
+           </a>
+          </span>
+          <span style="">
+           |
+          </span>
+          <span>
+           <a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=e3d1fc61-4c67-44ee-b815-e849def5a216&amp;ppid=c84ccdcd-2327-4f80-98e1-604a37e58d41&amp;sid=SUBSCRIBER_ID&amp;_bhlid=5e385064e40521226e8ebd03f030c4a30b516261">
+            3
+           </a>
+          </span>
+          <span style="">
+           |
+          </span>
+          <span>
+           <a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=9afc13ca-b323-464e-a674-b992143cc258&amp;ppid=c84ccdcd-2327-4f80-98e1-604a37e58d41&amp;sid=SUBSCRIBER_ID&amp;_bhlid=e2e8306867202cc43542fafb4bc11dae56c14e28">
+            4
+           </a>
+          </span>
+          <span style="">
+           |
+          </span>
+          <span>
+           <a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=36e7f97a-3a9e-4b58-95ab-b72e85cd83c3&amp;ppid=c84ccdcd-2327-4f80-98e1-604a37e58d41&amp;sid=SUBSCRIBER_ID&amp;_bhlid=52ca5ce794169ee0210247c8edc4e26d1a8a9533">
+            5
+           </a>
+          </span>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+    </table>
+   </td>
+  </tr>
+  
+  '''
+# ---
+# name: test_html_to_description[post_aa76678f-b955-4a29-927e-388a5e3410d4.html]
+  '''
+  <tr id="content-blocks">
+   <td align="center" class="email-card-body" style="padding-bottom:px;" valign="top">
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="none" width="100%">
+     <tr>
+      <td align="center" class="dd" style="padding:0px 10px;text-align:center;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        Friday 13th February issue is presented by WorkOS
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="padding-bottom:10px;padding-left:10px;padding-right:10px;padding-top:10px; " valign="top">
+       <table border="0" cellpadding="0" cellspacing="0" role="none" style="margin:0 auto 0 auto;">
+        <tr>
+         <td align="center" style="width:195px;" valign="top">
+          <a href="https://workos.com/docs/pipes?utm_source=pointer&amp;utm_medium=newsletter&amp;utm_campaign=q12026&amp;utm_content=no_rebuild?&amp;aid=recSyhq06k0OeoDUJ&amp;_bhlid=51c41cc318c6ad5c2cc0c43d18765a7b750fe64e" rel="noopener noreferrer nofollow" style="text-decoration:none;" target="_blank">
+           <img alt="" border="0" height="auto" src="https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/763c1dc8-c550-4a69-9385-104fe0aeb6d0/WorkOS__1_.png?t=1753778191" style="display:block;width:100%;border-radius:0px 0px 0px 0px;border-style:solid;border-width:0px 0px 0px 0px;box-sizing:border-box;border-color:#E5E7EB;" width="195"/>
+          </a>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="ship-third-party-integrations-witho" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;" valign="top">
+       <h2 style="color:#000000;font-weight:700;mso-line-height-alt:150.0%;">
+        <a class="link" href="https://workos.com/docs/pipes?utm_source=pointer&amp;utm_medium=newsletter&amp;utm_campaign=q12026&amp;utm_content=no_rebuild?&amp;aid=recJGbGeqR8ZnPiC5&amp;_bhlid=fb7fbb5f5c619442efdd41991617e58b73fd3731" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          Ship Third-Party Integrations Without Rebuilding OAuth
+         </span>
+        </a>
+       </h2>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        Connecting user accounts to third-party APIs always comes with the same plumbing: OAuth flows, token storage, refresh logic, and provider-specific quirks.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <a class="link" href="https://workos.com/blog/workos-pipes-third-party-integrations?utm_source=pointer&amp;utm_medium=newsletter&amp;utm_campaign=q12026&amp;utm_content=product_name_link?&amp;aid=recEfgdz1y2gLtWiT&amp;_bhlid=385a7dff1380e81abd174c88609ed9d8452645a3" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          WorkOS Pipes
+         </span>
+        </a>
+        removes that overhead. Users connect services like GitHub, Slack, Google, Salesforce, and other supported providers through a
+        <a class="link" href="https://workos.com/docs/widgets/pipes?utm_source=pointer&amp;utm_medium=newsletter&amp;utm_campaign=q12026&amp;utm_content=drop_in_widget?&amp;aid=recrdqPUJY6k1RpLI&amp;_bhlid=e97aebfd05621aff0b068450df95f5786ace7b3c" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          drop-in widget
+         </span>
+        </a>
+        . Your backend requests a valid access token from the Pipes API when needed, while Pipes handles credential storage and token refresh.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" id="simplify-integrations-today" style="color:#000000;font-weight:700;padding:0px 10px;text-align:center;" valign="top">
+       <h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;">
+        <a class="link" href="https://workos.com/docs/pipes?utm_source=pointer&amp;utm_medium=newsletter&amp;utm_campaign=q12026&amp;utm_content=simplify_integrations_cta?&amp;aid=recKykQXlK04yG7qO&amp;_bhlid=b407ac96b8393b2bf4173035e26eb644a4bdb6af" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          Simplify Integrations Today →
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="padding:0px 10px;text-align:center;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="14-more-lessons-from-14-years-at-go" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;">
+        <a class="link" href="https://addyo.substack.com/p/14-more-lessons-from-14-years-at?&amp;aid=rec3nPcWZNDYBhlMU&amp;_bhlid=45e01ce030eace56657272e9d0b154fd6c493406" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          14 More Lessons From 14 Years At Google
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Addy Osmani
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : “Some of the hardest lessons I’ve learned aren’t about how you work. They’re about how teams work: how decisions actually get made, where coordination breaks down, what separates the groups that ship from the ones that spin. These lessons pick up where the first left off. They’re less about being a better individual engineer and more about the systems around the engineering.”
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="career-advice" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          CareerAdvice
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="work-expands-time-vanishes-heres-wh" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;">
+        <a class="link" href="https://read.perspectiveship.com/p/planning-laws?&amp;aid=rechnXyVw6WZLA4iZ&amp;_bhlid=0079d642f29f96fdc3af4014d11f489d69d18a35" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          Work Expands. Time Vanishes. Here's Why.
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Michał Poczwardowski
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : “I’ve witnessed teams hiding real deadlines from each other. Afraid that if developers knew the real date, work would expand to fill it (Parkinson), while still taking longer than expected (Hofstadter). Some teams added multipliers to estimates, turning a 3-day estimate into 6 days automatically. This blurred what was being estimated in the first place.”
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="leadership-management" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          Leadership Management
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="the-enterprise-infrastructure-behin" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;">
+        <a class="link" href="https://workos.com/docs/pipes?utm_source=pointer&amp;utm_medium=newsletter&amp;utm_campaign=q12026&amp;utm_content=secondary_title?&amp;aid=recZZxBUPYcVTQ4hK&amp;_bhlid=cf2ea41166788337ac7479fc41f90ba5c91ce51a" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          The Enterprise Infrastructure Behind Successful AI Apps
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : Most AI apps fail to reach production not because of models, but because they lack enterprise infrastructure. This article breaks down the foundations teams need to scale AI responsibly, including identity, access control, auditability, and compliance. It shows how leading teams are building for production from day one.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <i>
+         Promoted by WorkOS
+        </i>
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="leadership-management" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          Tools AI
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="most-popular-from-last-issue" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;">
+        <a class="link" href="https://terriblesoftware.org/2026/02/02/why-am-i-doing-the-thinking-for-you/?&amp;aid=recZr6iEnh1EkFxvw&amp;_bhlid=72eab47e7717210b1758fa128549f10ec14e4287" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          Why Am I Doing The Thinking For You?
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Matheus Lima
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : “That sounds harsh, but it’s true. When you ask someone “what do you think?” without sharing what you think, you’re not collaborating, but more like outsourcing? You’re taking all the work you should have done (reading and understanding the doc, weighing the trade-offs, forming an opinion) and dumping it on someone else’s lap. It looks like a question, but it’s more like a task assignment.”
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="leadership-management" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          CareerAdvice
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" style="padding:0px 10px;text-align:right;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="padding:30px 10px 30px 10px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="d" role="none" style="background-color:#000000;border-color:#ffffff;border-radius:10px 10px 10px 10px;border-style:solid;border-width:0px 0px 0px 0px;" width="100%">
+        <tr>
+         <td align="center" class="dd" style="padding:20px 20px 20px 20px;" valign="top">
+          <table align="center" border="0" cellpadding="0" cellspacing="0" role="none" width="100%">
+           <tr>
+            <td align="center" class="i" valign="top">
+             <p style="color:#f3f4f6;font-weight:400;margin:0px;text-align:center;">
+              <i>
+               “Life shrinks or expands in proportion to one’s courage.”
+              </i>
+             </p>
+            </td>
+           </tr>
+           <tr>
+            <td height="14" style="line-height:1px;font-size:1px;height:14;">
+            </td>
+           </tr>
+           <tr>
+            <td align="center" class="h" style="color:#ffffff;font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-size:14px;font-weight:400;padding-bottom:12px;padding-top:12px;" valign="top">
+             – Anais Nin
+            </td>
+           </tr>
+          </table>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="programming-aphorisms" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;">
+        <a class="link" href="https://matklad.github.io/2026/02/11/programming-aphorisms.html?&amp;aid=recQXzDPKHg3Vuiju&amp;_bhlid=c7c4043c802ea207ef48e0a6d72f597b02b96747" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          Programming Aphorisms
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Alex Kladov
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : “A meta programming post - looking at my thought process when coding and trying to pin down what is programming “knowledge”. Turns out, a significant fraction of that is just reducing new problems to a vocabulary of known tricks. This is a personal, descriptive post, not a prescriptive post for you.”
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="thought-piece" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          ThoughtPiece
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="the-web-search-api-for-ai-apps-agen" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;">
+        <a class="link" href="https://serpapi.com/blog/the-web-search-api-for-ai-applications/?utm_source=pointer?&amp;aid=rece6f2vDLUIRlXCv&amp;_bhlid=abb760a6c7f2963d7178e1ca0ff49a627315689e" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          The Web Search API For AI Apps, Agents, And LLMs In 2026
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Hilman Ramadhan
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : Build AI apps without scraping headaches. Learn how a Web Search API extends model knowledge, delivers real-time data, and gives you full control and flexibility.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <i>
+         Promoted by SerpApi
+        </i>
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="search-api-ai" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          Search API AI
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="how-to-make-architecture-decisions-" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;">
+        <a class="link" href="https://lukasniessen.medium.com/how-to-make-architecture-decisions-rfcs-adrs-and-getting-everyone-aligned-ab82e5384d2f?&amp;aid=recHPA1INpLPpkgsp&amp;_bhlid=e3773013aea87be4570ba0867814cfc9b6947def" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          How to Make Architecture Decisions: RFCs, ADRs, and Getting Everyone Aligned
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Lukas Niessen
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : “The thing is, architecture decisions are different from regular code decisions. They’re harder to reverse, they affect more people, and they often involve trade-offs that aren’t purely technical. You need buy-in. You need the right people in the room. And you need a process that doesn’t turn into endless meetings or bikeshedding. Here’s the approach I’ve found works well, both in my consulting work and in teams I’ve led.”
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="architecture" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          Architecture
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="the-state-of-ai-in-2025-agents-inno" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;">
+        <a class="link" href="https://martinalderson.com/posts/two-kinds-of-ai-users-are-emerging/?&amp;aid=recfWlfS5aHz4eSFd&amp;_bhlid=451ebb47c662b82cda0a2ffc7dbc28d9aba3e011" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          Two Kinds Of AI Users Are Emerging. The Gap Between Them Is Astonishing.
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Martin Alderson
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : “It still shocks me how much difference there is between AI users. I think it explains a lot about the often confusing (to me) coverage in the media about AI and its productivity impact. I think it's clear there are two types of users to me now, and by extension, the organisations they work for.”
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="management-leadership-ai" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          Management Leadership AI
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="using-an-engineering-notebook" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;" valign="top">
+       <h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;">
+        <a class="link" href="https://ntietz.com/blog/using-an-engineering-notebook/?&amp;aid=recuVzHf9454dpzAf&amp;_bhlid=925a709b7796ed07f4211b4ad3105c5b203152cc" rel="noopener noreferrer nofollow" target="_blank">
+         <span>
+          Using An Engineering Notebook
+         </span>
+        </a>
+       </h1>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        — Nicole Tietz-Sokolskaya
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         tl;dr
+        </b>
+        : “One of my core software engineering practices is writing, by hand, in a physical notebook. It's one of the most important things I do to remain productive and effective. Maybe the single most important. And it's a practice that I see very few others using!”
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="right" class="dd" id="ai" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;" valign="top">
+       <h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;">
+        <span style="font-size:12px;">
+         <i>
+          CareerAdvice
+         </i>
+        </span>
+       </h6>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="null-pointer" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;" valign="top">
+       <h2 style="color:#000000;font-weight:700;mso-line-height-alt:150.0%;">
+        Null Pointer
+       </h2>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="padding-bottom:10px;padding-left:10px;padding-right:10px;padding-top:10px; " valign="top">
+       <table border="0" cellpadding="0" cellspacing="0" role="none" style="margin:0 auto 0 auto;">
+        <tr>
+         <td align="center" style="width:650px;" valign="top">
+          <img alt="" border="0" height="auto" src="https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/92d5338d-8048-44c4-8b17-a61e7248dd5f/37_uber-legacy.png?t=1770919976" style="display:block;width:100%;" width="650"/>
+         </td>
+        </tr>
+        <tr>
+         <td align="center" class="t" style="width:650px; padding: 4px 0px 4px 0px;" valign="top">
+          <p>
+           Uber-legacy
+          </p>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="padding:0px 10px;text-align:center;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <span style="font-size:0.8rem;">
+         Hand-drawn by
+        </span>
+        <span style="font-size:0.8rem;">
+         <a class="link" href="https://ma.nu/graphics/?_bhlid=f2d7550f60843e76ba01517ee5122a261dcde023" rel="noopener noreferrer nofollow" target="_blank">
+          <span>
+           Manu
+          </span>
+         </a>
+        </span>
+        <span style="font-size:0.8rem;">
+         . Got an idea for a cartoon? Click reply and let us know
+        </span>
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="most-popular-from-last-issue" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;" valign="top">
+       <h2 style="color:#000000;font-weight:700;mso-line-height-alt:150.0%;">
+        Most Popular From Last Issue
+       </h2>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         <a class="link" href="https://justoffbyone.com/posts/how-to-run-11s?&amp;aid=recQyHHDH5RYlCt9Z&amp;_bhlid=4a3d6fea99515495a2d8d3f11607e66421acfa6c" rel="noopener noreferrer nofollow" target="_blank">
+          <span>
+           Running 1:1s For Engineers
+          </span>
+         </a>
+        </b>
+        -
+        <b>
+        </b>
+        Can Duruk
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" id="notable-links" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;" valign="top">
+       <h2 style="color:#000000;font-weight:700;mso-line-height-alt:150.0%;">
+        Notable Links
+       </h2>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         <a class="link" href="https://github.com/homarr-labs/homarr?&amp;aid=recuT8HJQQ5RBz9q8&amp;_bhlid=9ce9c4c0b2abb2ccadeab6a01e5daadb34828c9e" rel="noopener noreferrer nofollow" target="_blank">
+          <span>
+           Homarr
+          </span>
+         </a>
+        </b>
+        :
+        <b>
+        </b>
+        Modern and easy to use dashboard.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         <a class="link" href="https://github.com/github/gh-aw?&amp;aid=recdANtoaXFd7LA1T&amp;_bhlid=d3f1c22b0bb2473b0d19c48cdfd2ae3f8cb15df8" rel="noopener noreferrer nofollow" target="_blank">
+          <span>
+           Gh-aw
+          </span>
+         </a>
+        </b>
+        :
+        <b>
+        </b>
+        GitHub agentic workflows.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         <a class="link" href="https://github.com/google/langextract?&amp;aid=recXgjTEkRjVeqRui&amp;_bhlid=81fe8a76c638bcdc99dd8e8bf433b655140e5fd8" rel="noopener noreferrer nofollow" target="_blank">
+          <span>
+           LangExtract
+          </span>
+         </a>
+        </b>
+        :
+        <b>
+        </b>
+        Structured information from unstructured text.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         <a class="link" href="https://github.com/tobi/qmd?&amp;aid=recTjmo4UiyBe33Dn&amp;_bhlid=6912507fcd751f71a666c2a14f0a0121f1e84c60" rel="noopener noreferrer nofollow" target="_blank">
+          <span>
+           QMD
+          </span>
+         </a>
+        </b>
+        :
+        <b>
+        </b>
+        CLI search engine for your docs.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="left" class="dd" style="padding:0px 10px;text-align:left;word-break:break-word;">
+       <p style="mso-line-height-alt:150.0%;">
+        <b>
+         <a class="link" href="https://github.com/swark-io/swark?&amp;aid=rec9fMAagMNdN1XVz&amp;_bhlid=c24f27529a733442397cab7089769701c910d7e4" rel="noopener noreferrer nofollow" target="_blank">
+          <span>
+           Swark
+          </span>
+         </a>
+        </b>
+        :
+        <b>
+        </b>
+        Create architecture diagrams from code automatically using LLMs.
+       </p>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="dd" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" valign="top">
+       <table align="center" border="0" cellpadding="0" cellspacing="0" class="j" role="none" width="96%">
+        <tr>
+         <td>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td style="padding:4px 10px">
+       <br/>
+      </td>
+     </tr>
+     <tr>
+      <td align="center" class="e" valign="top">
+       <table align="left" border="0" cellpadding="0" cellspacing="0" role="none">
+        <tr>
+         <td align="left" style="padding:10px 10px 10px;" valign="top">
+          <h3 style="">
+           How did you like this issue of Pointer?
+          </h3>
+          <p style="">
+           1 = Didn't enjoy it all // 5 = Really enjoyed it
+          </p>
+         </td>
+        </tr>
+        <tr>
+         <td align="left" style="padding:0px 10px 10px;" valign="top">
+          <span>
+           <a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=168ea9f2-7130-4ae4-8f04-7bf1bd8780ea&amp;ppid=b8438e87-40c5-4839-b300-09d9b1a33f57&amp;sid=SUBSCRIBER_ID&amp;_bhlid=9bc793aebb4d0205249bfc7c698f130e94fe4f49">
+            1
+           </a>
+          </span>
+          <span style="">
+           |
+          </span>
+          <span>
+           <a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=9e524ac8-f554-4474-b06d-a0a1b5f9e2d5&amp;ppid=b8438e87-40c5-4839-b300-09d9b1a33f57&amp;sid=SUBSCRIBER_ID&amp;_bhlid=19cb354b114a05029c8cff40df5ea489b93f1918">
+            2
+           </a>
+          </span>
+          <span style="">
+           |
+          </span>
+          <span>
+           <a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=e3d1fc61-4c67-44ee-b815-e849def5a216&amp;ppid=b8438e87-40c5-4839-b300-09d9b1a33f57&amp;sid=SUBSCRIBER_ID&amp;_bhlid=ec4070a028cdc40d220c04e89279a35ee2c5c4ce">
+            3
+           </a>
+          </span>
+          <span style="">
+           |
+          </span>
+          <span>
+           <a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=9afc13ca-b323-464e-a674-b992143cc258&amp;ppid=b8438e87-40c5-4839-b300-09d9b1a33f57&amp;sid=SUBSCRIBER_ID&amp;_bhlid=8caa249ed389a7a25615adb35619610a3f692a1d">
+            4
+           </a>
+          </span>
+          <span style="">
+           |
+          </span>
+          <span>
+           <a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=36e7f97a-3a9e-4b58-95ab-b72e85cd83c3&amp;ppid=b8438e87-40c5-4839-b300-09d9b1a33f57&amp;sid=SUBSCRIBER_ID&amp;_bhlid=ef24eb7574d1e4927cc1db202329efac51b95b19">
+            5
+           </a>
+          </span>
+         </td>
+        </tr>
+       </table>
+      </td>
+     </tr>
+     <tr>
+      <td style="padding:4px 10px">
+       <br/>
+       <br/>
+      </td>
+     </tr>
+    </table>
+   </td>
+  </tr>
+  
+  '''
+# ---

--- a/tests/fixtures/01b4cdda41.html
+++ b/tests/fixtures/01b4cdda41.html
@@ -1,0 +1,334 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Essential Reading For Engineering Leaders. Handpicked articles summarized into a 5‑minute read.">
+    <meta name="author" content="Suraj Kapoor">
+
+    <meta property="og:title" content="Essential Reading For Engineering Leaders"/>
+    <meta property="og:image" content="http://www.pointer.io/static/images/social-og.png"/>
+    <meta property="og:description" content="Handpicked articles summarized into a 5‑minute read."/>
+    <meta property="og:url" content="www.pointer.io"/>
+
+    <title>Pointer | Essential Reading For Engineering Leaders</title>
+
+    <link href="/static/css/main.css" rel="stylesheet">
+
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/static/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/static/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/static/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/static/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/static/safari-pinned-tab.svg"
+      color="#101720"
+    />
+    <meta name="msapplication-TileColor" content="#101720" />
+    <meta name="theme-color" content="#f3f4f6" />
+    
+    <script>
+	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+	  ga('create', 'UA-54273473-3', 'auto');
+	  ga('send', 'pageview');
+   </script>
+
+<!-- Google tag (gtag.js) -->
+   <script async src="https://www.googletagmanager.com/gtag/js?id=G-4MC7M40CEQ"></script>
+   <script>
+   window.dataLayer = window.dataLayer || [];
+   function gtag(){dataLayer.push(arguments);}
+   gtag('js', new Date());
+
+   gtag('config', 'G-4MC7M40CEQ');
+   </script>
+
+    <script>
+      !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+      posthog.init('phc_4ok8ZC2gD3gA0aIQ0jYS4RliamTWKPVuL4kNsmbQX94',{api_host:'https://us.i.posthog.com'})
+    </script>
+
+
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P9R9NX9');</script>
+  <!-- End Google Tag Manager -->
+
+
+  <!-- Facebook Pixel Code -->
+  <script>
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '6476529382457682');
+  fbq('track', 'PageView');
+  </script>
+  <noscript><img height="1" width="1" style="display:none"
+  src="https://www.facebook.com/tr?id=370244158087974&ev=PageView&noscript=1"
+  /></noscript>
+  <!-- End Facebook Pixel Code -->
+
+  <!-- Reddit Pixel --><script>!function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);rdt('init','t2_einsuv7w');rdt('track', 'PageVisit');</script><!-- DO NOT MODIFY --><!-- End Reddit Pixel -->
+  
+  </head>
+  <body class="flex flex-col bg-blue-950 font-grotesk text-gray-200">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P9R9NX9" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
+    <header class="bg-blue-950">
+      <nav
+        class="mx-auto flex items-center justify-between border-b border-blue-900/50 px-6 py-4 shadow-sm lg:px-8"
+        aria-label="Global"
+      >
+        <a href="/" class="-m-1.5 p-1.5 text-inherit">
+          <svg
+            clip-rule="evenodd"
+            fill-rule="evenodd"
+            stroke-linejoin="round"
+            stroke-miterlimit="2"
+            viewBox="0 0 334 69"
+            xmlns="http://www.w3.org/2000/svg"
+            class="max-h-full w-32 fill-gray-100"
+          >
+            <path
+              d="m425.633 1384.78-27.63-27.63-12.49-28.01-6.056 2.65 10.597 27.63v40.12h-36.335v-40.12l10.598-27.63-6.056-2.65-12.49 28.01-27.63 27.63-25.359-25.36 27.63-27.63 28.008-12.49-2.649-6.05-27.63 10.59h-40.121v-36.33h40.121l27.63 10.6 2.649-6.06-28.008-12.49-27.63-27.63 25.359-25.36 27.63 27.63 12.49 28.01 6.056-2.65-10.598-27.63v-40.12h36.335v40.12l-10.597 27.63 6.056 2.65 12.49-28.01 27.63-27.63 25.359 25.36-27.63 27.63-28.009 12.49 2.65 6.06 27.63-10.6h40.12v36.33h-40.12l-27.63-10.59-2.65 6.05 28.009 12.49 27.63 27.63z"
+              fill-rule="nonzero"
+              transform="matrix(.119681 0 0 .119681 71.822 -145.03)"
+            />
+            <g
+              transform="matrix(.210802 0 0 .210802 -157.384 -236.08)"
+            >
+              <path
+                d="m796.556 1338.23v99.92h-49.961v-264.95h103.707c13.626 0 25.485 2.21 35.578 6.63 10.094 4.41 18.484 10.22 25.17 17.41 6.687 7.19 11.734 15.39 15.14 24.6s5.11 18.61 5.11 28.2v9.08c0 9.84-1.704 19.49-5.11 28.96-3.406 9.46-8.453 17.91-15.14 25.35-6.686 7.45-15.076 13.44-25.17 17.98-10.093 4.54-21.952 6.82-35.578 6.82zm0-47.69h48.826c11.102 0 19.871-3.03 26.305-9.09 6.434-6.05 9.652-13.88 9.652-23.46v-4.55c0-9.58-3.218-17.41-9.652-23.46-6.434-6.06-15.203-9.09-26.305-9.09h-48.826z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1164.45 1346.55c0 15.65-2.65 29.46-7.95 41.45-5.3 11.98-12.49 22.08-21.57 30.28s-19.49 14.44-31.23 18.73c-11.73 4.29-24.03 6.44-36.9 6.44s-25.17-2.15-36.9-6.44c-11.74-4.29-22.15-10.53-31.229-18.73-9.083-8.2-16.275-18.3-21.574-30.28-5.299-11.99-7.948-25.8-7.948-41.45v-4.54c0-15.39 2.649-29.08 7.948-41.07 5.299-11.98 12.491-22.14 21.574-30.46 9.079-8.33 19.489-14.64 31.229-18.93 11.73-4.29 24.03-6.43 36.9-6.43s25.17 2.14 36.9 6.43c11.74 4.29 22.15 10.6 31.23 18.93 9.08 8.32 16.27 18.48 21.57 30.46 5.3 11.99 7.95 25.68 7.95 41.07zm-97.65 51.48c6.81 0 13.25-1.14 19.3-3.41 6.06-2.27 11.36-5.55 15.9-9.84s8.14-9.52 10.79-15.71c2.65-6.18 3.97-13.18 3.97-21v-7.57c0-7.83-1.32-14.83-3.97-21.01s-6.25-11.42-10.79-15.71-9.84-7.57-15.9-9.84c-6.05-2.27-12.49-3.4-19.3-3.4s-13.25 1.13-19.3 3.4c-6.06 2.27-11.36 5.55-15.9 9.84s-8.14 9.53-10.79 15.71-3.97 13.18-3.97 21.01v7.57c0 7.82 1.32 14.82 3.97 21 2.65 6.19 6.25 11.42 10.79 15.71s9.84 7.57 15.9 9.84c6.05 2.27 12.49 3.41 19.3 3.41z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1215.55 1392.73h63.58v-96.89h-59.04v-45.43h106.74v142.32h54.5v45.42h-165.78z"
+              />
+              <path
+                d="m1491.47 1438.15h-47.69v-187.74h47.69v28.01h6.81c4.29-10.59 11.23-18.8 20.82-24.6s20.82-8.7 33.69-8.7c9.08 0 17.59 1.45 25.54 4.35s14.95 7.38 21.01 13.44c6.06 6.05 10.79 13.75 14.19 23.08 3.41 9.34 5.11 20.44 5.11 33.31v118.85h-47.69v-106.74c0-13.37-3.21-23.9-9.65-31.6-6.43-7.7-15.71-11.54-27.82-11.54-14.13 0-24.66 4.73-31.6 14.19s-10.41 22.14-10.41 38.04z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1670.12 1250.41h55.64v-77.21h47.69v77.21h67.75v45.43h-67.75v85.53c0 7.57 3.4 11.36 10.22 11.36h50.71v45.42h-79.48c-8.58 0-15.58-2.78-21.01-8.33-5.42-5.55-8.13-12.62-8.13-21.2v-112.78h-55.64z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1949.07 1359.8c.25 5.55 1.57 10.66 3.97 15.33s5.68 8.7 9.84 12.11c4.17 3.41 8.96 6.06 14.39 7.95 5.42 1.89 11.16 2.84 17.22 2.84 11.86 0 20.94-2.08 27.25-6.25 6.31-4.16 10.85-9.14 13.62-14.95l40.88 22.71c-2.27 4.8-5.42 9.78-9.46 14.95s-9.27 9.91-15.71 14.2c-6.43 4.29-14.25 7.82-23.46 10.59-9.22 2.78-20 4.17-32.37 4.17-14.13 0-26.99-2.27-38.6-6.82-11.61-4.54-21.64-11.1-30.09-19.68-8.46-8.58-15.02-19.05-19.68-31.41-4.67-12.37-7.01-26.37-7.01-42.01v-2.28c0-14.38 2.46-27.5 7.38-39.36s11.67-21.95 20.25-30.28 18.61-14.82 30.09-19.49c11.49-4.67 23.79-7 36.91-7 16.15 0 30.02 2.83 41.63 8.51s21.2 12.87 28.77 21.58c7.57 8.7 13.12 18.29 16.65 28.76s5.3 20.63 5.3 30.47v25.36zm45.04-71.53c-12.11 0-21.95 3.09-29.52 9.27s-12.49 13.31-14.76 21.38h88.56c-1.51-8.83-6.24-16.15-14.19-21.95s-17.98-8.7-30.09-8.7z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m2129.61 1250.41h79.48v27.26h6.82c3.53-10.35 9.52-18.36 17.97-24.04 8.46-5.68 18.61-8.51 30.47-8.51 18.68 0 33.69 5.86 45.04 17.6 11.36 11.73 17.04 29.58 17.04 53.55v8.33l-49.21 4.54v-5.3c0-10.34-2.65-18.61-7.95-24.79s-13.24-9.27-23.84-9.27-18.93 3.66-24.98 10.98c-6.06 7.31-9.09 17.78-9.09 31.41v60.56h43.15v45.42h-129.44v-45.42h38.6v-96.89h-34.06z"
+                fill-rule="nonzero"
+              />
+            </g>
+          </svg>
+        </a>
+        <div class="flex gap-x-12">
+          
+        </div>
+      </nav>
+    </header>
+    
+
+<div class="bg-white">
+	<div class="w-[670px] max-w-full m-auto py-8">
+		<div class="pb-2 px-1">
+			<h1 class="m-0 text-2xl text-gray-950 font-bold">Issue #489</h1>
+			<time datetime="2024-02-16 14:00:00" class="mt-0 text-gray-500">February 16, 2024</time>
+			<div class="flex justify-between text-center py-2">
+				
+					<a href="/archives/a9c897bd75" class="inline-block mt-3 w-1/4 flex-none rounded-md bg-yellow-300 px-3.5 py-3 text-sm font-bold text-gray-900 shadow-sm hover:bg-yellow-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-300">&laquo; Prev</a>
+				
+				
+					<a href="/archives/f3d6fdc56d" class="inline-block mt-3 w-1/4 flex-none rounded-md bg-yellow-300 px-3.5 py-3 text-sm font-bold text-gray-900 shadow-sm hover:bg-yellow-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-300">Next &raquo;</a>
+				
+			</div>
+		</div>
+		<div class="text-transparent"><!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office"><head>
+<!--[if gte mso 15]>
+<xml>
+<o:OfficeDocumentSettings>
+<o:AllowPNG/>
+<o:PixelsPerInch>96</o:PixelsPerInch>
+</o:OfficeDocumentSettings>
+</xml>
+<![endif]-->
+<meta charset="UTF-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>Issue #489</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Space+Mono:400,400i,700,700i,900,900i"/><style>          img{-ms-interpolation-mode:bicubic;} 
+          table, td{mso-table-lspace:0pt; mso-table-rspace:0pt;} 
+          .mceStandardButton, .mceStandardButton td, .mceStandardButton td a{mso-hide:all !important;} 
+          p, a, li, td, blockquote{mso-line-height-rule:exactly;} 
+          p, a, li, td, body, table, blockquote{-ms-text-size-adjust:100%; -webkit-text-size-adjust:100%;} 
+          @media only screen and (max-width: 480px){
+            body, table, td, p, a, li, blockquote{-webkit-text-size-adjust:none !important;} 
+          }
+          .mcnPreviewText{display: none !important;} 
+          .bodyCell{margin:0 auto; padding:0; width:100%;}
+          .ExternalClass, .ExternalClass p, .ExternalClass td, .ExternalClass div, .ExternalClass span, .ExternalClass font{line-height:100%;} 
+          .ReadMsgBody{width:100%;} .ExternalClass{width:100%;} 
+          a[x-apple-data-detectors]{color:inherit !important; text-decoration:none !important; font-size:inherit !important; font-family:inherit !important; font-weight:inherit !important; line-height:inherit !important;} 
+            body{height:100%; margin:0; padding:0; width:100%; background: #ffffff;}
+            p{margin:0; padding:0;} 
+            table{border-collapse:collapse;} 
+            td, p, a{word-break:break-word;} 
+            h1, h2, h3, h4, h5, h6{display:block; margin:0; padding:0;} 
+            img, a img{border:0; height:auto; outline:none; text-decoration:none;} 
+            a[href^="tel"], a[href^="sms"]{color:inherit; cursor:default; text-decoration:none;} 
+            li p {margin: 0 !important;}
+            .ProseMirror a {
+                pointer-events: none;
+            }
+            @media only screen and (max-width: 480px){
+                body{width:100% !important; min-width:100% !important; } 
+                body.mobile-native {
+                    -webkit-user-select: none; user-select: none; transition: transform 0.2s ease-in; transform-origin: top center;
+                }
+                body.mobile-native.selection-allowed a, body.mobile-native.selection-allowed .ProseMirror {
+                    user-select: auto;
+                    -webkit-user-select: auto;
+                }
+                colgroup{display: none;}
+                img{height: auto !important;}
+                .mceWidthContainer{max-width: 660px !important;}
+                .mceColumn{display: block !important; width: 100% !important;}
+                .mceColumn-forceSpan{display: table-cell !important; width: auto !important;}
+                .mceColumn-forceSpan .mceButton a{min-width:0 !important;}
+                .mceBlockContainer{padding-right:16px !important; padding-left:16px !important;} 
+                .mceBlockContainerE2E{padding-right:0px; padding-left:0px;} 
+                .mceSpacing-24{padding-right:16px !important; padding-left:16px !important;}
+                .mceImage, .mceLogo{width: 100% !important; height: auto !important;} 
+                .mceFooterSection .mceText, .mceFooterSection .mceText p{font-size: 16px !important; line-height: 140% !important;}
+                .mceText, .mceText p{font-size: 16px !important; line-height: 140% !important;}
+                h1{font-size: 30px !important; line-height: 120% !important;}
+                h2{font-size: 26px !important; line-height: 120% !important;}
+                h3{font-size: 20px !important; line-height: 125% !important;}
+                h4{font-size: 18px !important; line-height: 125% !important;}
+            }
+            @media only screen and (max-width: 640px){
+                .mceClusterLayout td{padding: 4px !important;} 
+            }
+            div[contenteditable="true"] {outline: 0;}
+            .ProseMirror .empty-node, .ProseMirror:empty {position: relative;}
+            .ProseMirror .empty-node::before, .ProseMirror:empty::before {
+                position: absolute;
+                left: 0;
+                right: 0;
+                color: rgba(0,0,0,0.2);
+                cursor: text;
+            }
+            .ProseMirror .empty-node:hover::before, .ProseMirror:empty:hover::before {
+                color: rgba(0,0,0,0.3);
+            }
+            .ProseMirror h1.empty-node:only-child::before,
+            .ProseMirror h2.empty-node:only-child::before,
+            .ProseMirror h3.empty-node:only-child::before,
+            .ProseMirror h4.empty-node:only-child::before {
+                content: 'Heading';
+            }
+            .ProseMirror p.empty-node:only-child::before, .ProseMirror:empty::before {
+                content: 'Start typing...';
+            }
+            a .ProseMirror p.empty-node::before, a .ProseMirror:empty::before {
+                content: '';
+            }
+            .mceText, .ProseMirror {
+                white-space: pre-wrap;
+            }
+body, #bodyTable { background-color: rgb(255, 255, 255); }.mceText, .mceLabel { font-family: "Space Mono", Courier, Georgia, serif; }.mceText, .mceLabel { color: rgb(0, 0, 0); }.mceText p { margin-bottom: 0px; }.mceText label { margin-bottom: 0px; }.mceText input { margin-bottom: 0px; }.mceSpacing-12 .mceInput + .mceErrorMessage { margin-top: -6px; }.mceText p { margin-bottom: 0px; }.mceText label { margin-bottom: 0px; }.mceText input { margin-bottom: 0px; }.mceSpacing-24 .mceInput + .mceErrorMessage { margin-top: -12px; }.mceInput { background-color: transparent; border: 2px solid rgb(208, 208, 208); width: 60%; color: rgb(77, 77, 77); display: block; }.mceInput[type="radio"], .mceInput[type="checkbox"] { float: left; margin-right: 12px; display: inline; width: auto !important; }.mceLabel > .mceInput { margin-bottom: 0px; margin-top: 2px; }.mceLabel { display: block; }.mceText p { color: rgb(0, 0, 0); font-family: "Space Mono", Courier, Georgia, serif; font-size: 14px; font-weight: normal; line-height: 1.5; text-align: left; letter-spacing: 0px; direction: ltr; }.mceText a { color: rgb(0, 0, 0); font-style: normal; font-weight: normal; text-decoration: underline; direction: ltr; }
+@media only screen and (max-width: 480px) {
+            .mceText p { font-size: 16px !important; line-height: 1.5 !important; }
+          }
+@media only screen and (max-width: 480px) {
+            .mceBlockContainer { padding-left: 16px !important; padding-right: 16px !important; }
+          }
+#dataBlockId-9 p, #dataBlockId-9 h1, #dataBlockId-9 h2, #dataBlockId-9 h3, #dataBlockId-9 h4, #dataBlockId-9 ul { text-align: center; }#dataBlockId-76 p, #dataBlockId-76 h1, #dataBlockId-76 h2, #dataBlockId-76 h3, #dataBlockId-76 h4, #dataBlockId-76 ul { line-height: 1.5; text-align: left; }#dataBlockId-91 p, #dataBlockId-91 h1, #dataBlockId-91 h2, #dataBlockId-91 h3, #dataBlockId-91 h4, #dataBlockId-91 ul { line-height: 1.5; text-align: left; }#dataBlockId-98 p, #dataBlockId-98 h1, #dataBlockId-98 h2, #dataBlockId-98 h3, #dataBlockId-98 h4, #dataBlockId-98 ul { line-height: 1.5; text-align: left; }#dataBlockId-109 p, #dataBlockId-109 h1, #dataBlockId-109 h2, #dataBlockId-109 h3, #dataBlockId-109 h4, #dataBlockId-109 ul { line-height: 1.5; text-align: left; }#dataBlockId-116 p, #dataBlockId-116 h1, #dataBlockId-116 h2, #dataBlockId-116 h3, #dataBlockId-116 h4, #dataBlockId-116 ul { line-height: 1.5; text-align: left; }#dataBlockId-119 p, #dataBlockId-119 h1, #dataBlockId-119 h2, #dataBlockId-119 h3, #dataBlockId-119 h4, #dataBlockId-119 ul { line-height: 1.5; text-align: left; }#dataBlockId-138 p, #dataBlockId-138 h1, #dataBlockId-138 h2, #dataBlockId-138 h3, #dataBlockId-138 h4, #dataBlockId-138 ul { line-height: 1.5; text-align: left; }#dataBlockId-141 p, #dataBlockId-141 h1, #dataBlockId-141 h2, #dataBlockId-141 h3, #dataBlockId-141 h4, #dataBlockId-141 ul { line-height: 1.5; text-align: left; }#dataBlockId-142 p, #dataBlockId-142 h1, #dataBlockId-142 h2, #dataBlockId-142 h3, #dataBlockId-142 h4, #dataBlockId-142 ul { line-height: 1.5; text-align: left; }#dataBlockId-145 p, #dataBlockId-145 h1, #dataBlockId-145 h2, #dataBlockId-145 h3, #dataBlockId-145 h4, #dataBlockId-145 ul { line-height: 1.5; text-align: left; }#dataBlockId-155 p, #dataBlockId-155 h1, #dataBlockId-155 h2, #dataBlockId-155 h3, #dataBlockId-155 h4, #dataBlockId-155 ul { line-height: 1.5; text-align: left; }</style></head>
+<body>
+<!---->
+<!--[if !gte mso 9]><!----><span class="mcnPreviewText" style="display:none; font-size:0px; line-height:0px; max-height:0px; max-width:0px; opacity:0; overflow:hidden; visibility:hidden; mso-hide:all;">A Reading Club For Software Developers</span><!--<![endif]-->
+<!---->
+<center>
+<table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="bodyTable" style="background-color: rgb(255, 255, 255);">
+<tbody><tr>
+<td class="bodyCell" align="center" valign="top">
+<table id="root" border="0" cellpadding="0" cellspacing="0" width="100%"><tbody data-block-id="54" class="mceWrapper"><tr><td align="center" valign="top" class="mceWrapperOuter"><!--[if (gte mso 9)|(IE)]><table align="center" border="0" cellspacing="0" cellpadding="0" width="660" style="width:660px;"><tr><td><![endif]--><table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width:660px" role="presentation"><tbody><tr><td style="background-color:#ffffff;background-position:center;background-repeat:no-repeat;background-size:cover" class="mceWrapperInner" valign="top"><table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation" data-block-id="12"><tbody><tr class="mceRow"><td style="background-position:center;background-repeat:no-repeat;background-size:cover" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tbody><tr><td style="padding-top:0;padding-bottom:0" class="mceColumn" data-block-id="-4" valign="top" colspan="12" width="100%"><table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tbody><tr><td style="background-color:#3e4954;padding-top:0;padding-bottom:0;padding-right:0;padding-left:0" class="mceBlockContainer" align="center" valign="top"><table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" data-block-id="55"><tbody><tr class="mceStandardButton"><td style="background-color:#3e4954;border-radius:0;text-align:center" class="mceButton" valign="top"><a href="https://www.pointer.io/" target="_blank" style="background-color:#3e4954;border-radius:0;border:1px solid #3e4954;color:#fabf80;display:block;font-family:'Space Mono', 'Courier', Georgia, serif;font-size:20px;font-weight:bold;font-style:normal;padding:16px 28px;text-decoration:none;min-width:30px;text-align:center;direction:ltr;letter-spacing:0px">pointer.io</a></td></tr><tr>
+<!--[if mso]>
+<td align="center">
+<v:roundrect xmlns:v="urn:schemas-microsoft-com:vml"
+xmlns:w="urn:schemas-microsoft-com:office:word"
+href="https://www.pointer.io/"
+style="v-text-anchor:middle; width:180.41px; height:63.5px;"
+arcsize="0%"
+strokecolor="#3e4954"
+strokeweight="1px"
+fillcolor="#3e4954">
+<v:stroke dashstyle="solid"/>
+<w:anchorlock />
+<center style="
+color: #fabf80;
+display: block;
+font-family: 'Space Mono', 'Courier', Georgia, serif;
+font-size: 20;
+font-style: normal;
+font-weight: bold;
+letter-spacing: 0px;
+text-decoration: none;
+text-align: center;
+direction: ltr;"
+>
+pointer.io
+</center>
+</v:roundrect>
+</td>
+<![endif]-->
+</tr></tbody></table></td></tr><tr><td style="padding-top:10px;padding-bottom:10px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="48" class="mceText" id="dataBlockId-48" style="width:100%"><p style="text-align: center;"><br/></p><p style="text-align: center;" class="last-child">Friday 16th February’s issue is presented by Hookdeck</p></div></td></tr><tr><td style="background-color:#ffffff;padding-top:15px;padding-bottom:15px;padding-right:15px;padding-left:15px" class="mceBlockContainer" align="center" valign="top"><a href="https://hookdeck.com/?ref=pointer-489" style="display:block" target="_blank" data-block-id="47"><img width="330" height="auto" style="border:0;width:330px;height:auto;max-width:1417px !important;border-radius:0;display:block" alt="" src="https://mcusercontent.com/e9492ff27d760c578a39d0675/images/0a375603-1f38-5d2c-2516-1421bc712926.png" role="presentation" class="imageDropZone mceImage"/></a></td></tr><tr><td style="padding-top:10px;padding-bottom:10px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="91" class="mceText" id="dataBlockId-91" style="width:100%"><p><a href="https://hookdeck.com/?ref=pointer-489" target="_blank"><strong><span style="font-size: 16px">Asynchronous Messaging Platform For Engineering Teams</span></strong></a></p><p><br/></p><p><a href="https://hookdeck.com/?ref=pointer-489" target="_blank">Hookdeck</a> is an Event Gateway: A platform offering asynchronous messaging infrastructure and developer tooling for your full software development lifecycle.</p><p><br/></p><p>Our platform is an alternative component in your event-driven architecture to Amazon EventBridge, Azure EventGrid, Google EventArc, or hosted Kafka.</p><p><br/></p><p class="last-child">With <a href="https://hookdeck.com/?ref=pointer-489" target="_blank">Hookdeck</a> you can reliably receive, verify, transform, filter, route, rate limit, deliver, retry, and, observe messages at scale.</p></div></td></tr><tr><td style="padding-top:20px;padding-bottom:20px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="92" class="mceText" id="dataBlockId-92" style="width:100%"><p style="text-align: center;" class="last-child"><a href="https://hookdeck.com/?ref=pointer-489" target="_blank"><strong><span style="font-size: 20px">Try Hookdeck For Free</span></strong></a></p></div></td></tr><tr><td style="background-color:transparent;padding-top:5px;padding-bottom:5px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:transparent" role="presentation" data-block-id="43"><tbody><tr><td style="min-width:100%;border-top:2px solid #000000" valign="top"></td></tr></tbody></table></td></tr><tr><td style="padding-top:20px;padding-bottom:0;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="116" class="mceText" id="dataBlockId-116" style="width:100%"><p><a href="https://tidyfirst.substack.com/p/the-pleasure-of-pattern" target="_blank"><strong><span style="font-size: 20px">The Pleasure Of Pattern</span></strong></a></p><p>— Kent Beck</p><p><br/></p><p><strong>tl;dr</strong>: For over 20 years, Kent has asked why are so many programmers musicians? He’s finally able to answer this: “talent for music and programming occur together because accomplishment in each relies on enjoying seeing patterns. See a pattern, feel good, look for more patterns.” He believes his chaotic early life left him with a brain wired to crave moments of order... and the innate ability to see patterns led him to activities where he got frequent mental rewards, and this is what drives his desire to program. </p><p><br/></p><p style="text-align: right;" class="last-child"><em><span style="font-size: 12px"> </span></em><a href="http://www.pointer.io/tags/career-advice" target="_blank"><em><span style="font-size: 12px">CareerAdvice</span></em></a></p></div></td></tr><tr><td style="padding-top:0;padding-bottom:0;padding-right:15px;padding-left:0" class="mceBlockContainer" align="right" valign="top"><a href="mailto:?subject=The%20Pleasure%20Of%20Pattern&body=I'm%20sharing%20this%20article%20I%20found%20on%20www.pointer.io%3A%0D%0A%0D%0AThe%20Pleasure%20Of%20Pattern%0D%0Ahttps%3A%2F%2Ftidyfirst.substack.com%2Fp%2Fthe-pleasure-of-pattern%0D%0A" style="display:block" target="_blank" data-block-id="140"><img width="38" height="auto" style="border:0;width:38px;height:auto;max-width:64px !important;display:block" alt="" src="https://mcusercontent.com/e9492ff27d760c578a39d0675/images/5007b776-f11f-9e3f-6747-ec4408bb95b0.png" role="presentation" class="imageDropZone mceImage"/></a></td></tr><tr><td style="background-color:transparent;padding-top:5px;padding-bottom:5px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:transparent" role="presentation" data-block-id="139"><tbody><tr><td style="min-width:100%;border-top:2px solid #3e4954" valign="top"></td></tr></tbody></table></td></tr><tr><td style="padding-top:20px;padding-bottom:0;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="138" class="mceText" id="dataBlockId-138" style="width:100%"><p><a href="https://review.firstround.com/25-questions-for-reference-calls" target="_blank"><strong><span style="font-size: 20px">Add More Rigor To Your Reference Calls With These 25 Questions</span></strong></a></p><p><br/></p><p><strong>tl;dr</strong>: 25 questions including: (1) How does this person compare to the best you’ve ever seen in the role? (2) On a scale of 1 - 100, how would you rank this person? (3) On a scale of 1-10, how do you rate XYZ on specific trait or ability? (4) Can you tell me about a project that would have failed without the candidate? (5) What haven’t I asked that, if you were me, you would want to know about this person?  </p><p><br/></p><p style="text-align: right;" class="last-child"><em><span style="font-size: 12px"> </span></em><a href="http://www.pointer.io/tags/management" target="_blank"><em><span style="font-size: 12px">Management</span></em></a><em><span style="font-size: 12px"> </span></em><a href="http://www.pointer.io/tags/hiring" target="_blank"><em><span style="font-size: 12px">Hiring</span></em></a></p></div></td></tr><tr><td style="padding-top:0;padding-bottom:0;padding-right:15px;padding-left:0" class="mceBlockContainer" align="right" valign="top"><a href="mailto:?subject=Add%20More%20Rigor%20To%20Your%20Reference%20Calls%20With%20These%2025%20Questions&body=I'm%20sharing%20this%20article%20I%20found%20on%20www.pointer.io%3A%0D%0A%0D%0AAdd%20More%20Rigor%20To%20Your%20Reference%20Calls%20With%20These%2025%20Questions%0D%0Ahttps%3A%2F%2Freview.firstround.com%2F25-questions-for-reference-calls%0D%0A" style="display:block" target="_blank" data-block-id="133"><img width="38" height="auto" style="border:0;width:38px;height:auto;max-width:64px !important;display:block" alt="" src="https://mcusercontent.com/e9492ff27d760c578a39d0675/images/5007b776-f11f-9e3f-6747-ec4408bb95b0.png" role="presentation" class="imageDropZone mceImage"/></a></td></tr><tr><td style="background-color:transparent;padding-top:5px;padding-bottom:5px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:transparent" role="presentation" data-block-id="126"><tbody><tr><td style="min-width:100%;border-top:2px solid #3e4954" valign="top"></td></tr></tbody></table></td></tr><tr><td style="padding-top:20px;padding-bottom:0;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="141" class="mceText" id="dataBlockId-141" style="width:100%"><p><a href="https://hookdeck.com/blog/event-driven-architectrure-fundamentals-pitfalls?ref=pointer-489" target="_blank"><strong><span style="font-size: 20px">Event-Driven Architecture Fundamentals and Pitfalls (and How to Avoid Them)</span></strong></a></p><p>— James Higginbotham</p><p><br/></p><p><strong>tl;dr</strong>: With over 20 years of API and microservices experience, James summarizes the fundamentals of event-driven architecture, including (1) message types: command, reply, and event (2) what constitutes a message, including body, headers, and network protocol (3) message interaction patterns such as request-reply, fire-and-follow-up, and fire-and-forget (4) event design patterns: event notifications, event-carried state transfer, using hypermedia links in events, and event batching. Throughout, he highlights common pitfalls and the best practices to avoid them. </p><p><br/></p><p><em>Promoted by Hookdeck</em></p><p style="text-align: right;" class="last-child"><a href="http://www.pointer.io/tags/architecture" target="_blank"><em><span style="font-size: 12px">Architecture</span></em></a></p></div></td></tr><tr><td style="padding-top:0;padding-bottom:0;padding-right:15px;padding-left:0" class="mceBlockContainer" align="right" valign="top"><a href="mailto:?subject=Event-Driven%20Architecture%20Fundamentals%20and%20Pitfalls%20(and%20How%20to%20Avoid%20Them)&body=I'm%20sharing%20this%20article%20I%20found%20on%20www.pointer.io%3A%0D%0A%0D%0AEvent-Driven%20Architecture%20Fundamentals%20and%20Pitfalls%20(and%20How%20to%20Avoid%20Them)%0D%0Ahttps%3A%2F%2Fhookdeck.com%2Fblog%2Fevent-driven-architectrure-fundamentals-pitfalls%3Fref%3Dpointer-489%0D%0A" style="display:block" target="_blank" data-block-id="134"><img width="38" height="auto" style="border:0;width:38px;height:auto;max-width:64px !important;display:block" alt="" src="https://mcusercontent.com/e9492ff27d760c578a39d0675/images/5007b776-f11f-9e3f-6747-ec4408bb95b0.png" role="presentation" class="imageDropZone mceImage"/></a></td></tr><tr><td style="background-color:transparent;padding-top:5px;padding-bottom:5px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:transparent" role="presentation" data-block-id="99"><tbody><tr><td style="min-width:100%;border-top:2px solid #3e4954" valign="top"></td></tr></tbody></table></td></tr><tr><td style="padding-top:20px;padding-bottom:0;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="145" class="mceText" id="dataBlockId-145" style="width:100%"><p><a href="https://world.hey.com/dhh/the-compounding-seeds-of-creativity-e7e212c0" target="_blank"><strong><span style="font-size: 20px">The Compounding Seeds Of Creativity</span></strong></a></p><p>— David Heinemeier Hansson</p><p><br/><strong>tl;dr</strong>: “Early on in my career, I learned a very important lesson about creativity: It can’t be saved for later. Creativity is perishable, just like inspiration. It has to be discharged regularly or it will spoil. And if you let enough of it go to waste, eventually your talents will sour and shrivel with it.” David discusses how the best folks are able to find creativity in the mundane parts of their jobs, and that is what separates them.  </p><p><br/></p><p style="text-align: right;" class="last-child"><em><span style="font-size: 12px"> </span></em> <a href="http://www.pointer.io/tags/career-advice" target="_blank"><em><span style="font-size: 12px">CareerAdvice</span></em></a></p></div></td></tr><tr><td style="padding-top:0;padding-bottom:0;padding-right:15px;padding-left:0" class="mceBlockContainer" align="right" valign="top"><a href="mailto:?subject=The%20Compounding%20Seeds%20Of%20Creativity&body=I'm%20sharing%20this%20article%20I%20found%20on%20www.pointer.io%3A%0D%0A%0D%0AThe%20Compounding%20Seeds%20Of%20Creativity%0D%0Ahttps%3A%2F%2Fworld.hey.com%2Fdhh%2Fthe-compounding-seeds-of-creativity-e7e212c0%0D%0A" style="display:block" target="_blank" data-block-id="146"><img width="38" height="auto" style="border:0;width:38px;height:auto;max-width:64px !important;display:block" alt="" src="https://mcusercontent.com/e9492ff27d760c578a39d0675/images/5007b776-f11f-9e3f-6747-ec4408bb95b0.png" role="presentation" class="imageDropZone mceImage"/></a></td></tr><tr><td style="background-color:transparent;padding-top:5px;padding-bottom:5px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:transparent" role="presentation" data-block-id="103"><tbody><tr><td style="min-width:100%;border-top:2px solid #3e4954" valign="top"></td></tr></tbody></table></td></tr><tr><td style="background-color:transparent;padding-top:0;padding-bottom:0;padding-right:0;padding-left:0" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:transparent" role="presentation" data-block-id="63"><tbody><tr><td style="min-width:100%;border-top:20px solid transparent" valign="top"></td></tr></tbody></table></td></tr><tr><td style="background-color:#3e4954;padding-top:20px;padding-bottom:20px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="62" class="mceText" id="dataBlockId-62" style="width:100%"><p style="text-align: center;"><em><strong><span style="color:#ffffff;">“Creativity is intelligence having fun.”</span></strong></em></p><p style="text-align: center;"><br/></p><p style="text-align: center;" class="last-child"><strong><span style="color:#ffffff;">– Albert Einstein</span></strong></p></div></td></tr><tr><td style="background-color:transparent;padding-top:0;padding-bottom:0;padding-right:0;padding-left:0" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:transparent" role="presentation" data-block-id="64"><tbody><tr><td style="min-width:100%;border-top:20px solid transparent" valign="top"></td></tr></tbody></table></td></tr><tr><td style="background-color:transparent;padding-top:5px;padding-bottom:5px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:transparent" role="presentation" data-block-id="117"><tbody><tr><td style="min-width:100%;border-top:2px solid #3e4954" valign="top"></td></tr></tbody></table></td></tr><tr><td style="padding-top:20px;padding-bottom:0;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="119" class="mceText" id="dataBlockId-119" style="width:100%"><p><a href="https://newsletter.systemdesign.one/p/hotstar-architecture" target="_blank"><strong><span style="font-size: 20px">How Disney+ Hotstar Delivered 5 Billion Emojis in Real Time</span></strong></a></p><p>— Neo Kim</p><p><br/></p><p><strong>tl;dr</strong>: This post outlines how Disney+ Hotstar delivered billions of emojis in real-time during the cricket World Cup in India to create a more engaging live experience. The post described how emojis were received from clients, processed and delivered at scale.</p><p style="text-align: right;"><br/></p><p style="text-align: right;" class="last-child"><a href="http://www.pointer.io/tags/scale" target="_blank"><em><span style="font-size: 12px">Scale</span></em></a><em><span style="font-size: 12px"> </span></em><a href="http://www.pointer.io/tags/architecture" target="_blank"><em><span style="font-size: 12px">Architecture</span></em></a></p></div></td></tr><tr><td style="padding-top:0;padding-bottom:0;padding-right:15px;padding-left:0" class="mceBlockContainer" align="right" valign="top"><a href="mailto:?subject=How%20Disney%2B%20Hotstar%20Delivered%205%20Billion%20Emojis%20in%20Real%20Time&body=I'm%20sharing%20this%20article%20I%20found%20on%20www.pointer.io%3A%0D%0A%0D%0AHow%20Disney%2B%20Hotstar%20Delivered%205%20Billion%20Emojis%20in%20Real%20Time%0D%0Ahttps%3A%2F%2Fnewsletter.systemdesign.one%2Fp%2Fhotstar-architecture%0D%0A" style="display:block" target="_blank" data-block-id="130"><img width="38" height="auto" style="border:0;width:38px;height:auto;max-width:64px !important;display:block" alt="" src="https://mcusercontent.com/e9492ff27d760c578a39d0675/images/5007b776-f11f-9e3f-6747-ec4408bb95b0.png" role="presentation" class="imageDropZone mceImage"/></a></td></tr><tr><td style="background-color:transparent;padding-top:5px;padding-bottom:5px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:transparent" role="presentation" data-block-id="144"><tbody><tr><td style="min-width:100%;border-top:2px solid #3e4954" valign="top"></td></tr></tbody></table></td></tr><tr><td style="padding-top:20px;padding-bottom:0;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="142" class="mceText" id="dataBlockId-142" style="width:100%"><p><a href="https://linearb.io/blog/measure-generative-ai-impact?utm_source=Pointer&utm_medium=promo&utm_campaign=Email+-+External+-+GenAI+Measurement+Blog" target="_blank"><strong><span style="font-size: 20px">How To Measure The Impact Of Generative AI Code</span></strong></a></p><p>— Ben Lloyd Pearson</p><p><br/><strong>tl;dr</strong>: What’s the ROI of your GenAI code? By the end of 2024, GenAI is projected to generate 20% of all code – or 1 in every 5 lines. Learn how to use PR labels to get telemetry on GenAI code, allowing metric tracking that compares AI-generated code against unlabeled PRs. With this free automation, you can track the ROI of your GenAI investments and identify potential security and compliance risks.</p><p><br/></p><p><em>Promoted by LinearB</em></p><p style="text-align: right;" class="last-child"><a href="http://www.pointer.io/tags/management" target="_blank"><em><span style="font-size: 12px">Management</span></em></a><a href="http://www.pointer.io/tags/useful-tool" target="_blank" style="text-decoration: none;"><em><span style="font-size: 12px"> </span></em></a><a href="http://www.pointer.io/tags/ai" target="_blank"><em><span style="font-size: 12px">AI</span></em></a></p></div></td></tr><tr><td style="padding-top:0;padding-bottom:0;padding-right:15px;padding-left:0" class="mceBlockContainer" align="right" valign="top"><a href="mailto:?subject=How%20To%20Measure%20The%20Impact%20Of%20Generative%20AI%20Code&body=I'm%20sharing%20this%20article%20I%20found%20on%20www.pointer.io%3A%0D%0A%0D%0AHow%20To%20Measure%20The%20Impact%20Of%20Generative%20AI%20Code%0D%0Ahttps%3A%2F%2Flinearb.io%2Fblog%2Fmeasure-generative-ai-impact%3Futm_source%3DPointer%26utm_medium%3Dpromo%26utm_campaign%3DEmail%2B-%2BExternal%2B-%2BGenAI%2BMeasurement%2BBlog%0D%0A" style="display:block" target="_blank" data-block-id="149"><img width="38" height="auto" style="border:0;width:38px;height:auto;max-width:64px !important;display:block" alt="" src="https://mcusercontent.com/e9492ff27d760c578a39d0675/images/5007b776-f11f-9e3f-6747-ec4408bb95b0.png" role="presentation" class="imageDropZone mceImage"/></a></td></tr><tr><td style="background-color:transparent;padding-top:5px;padding-bottom:5px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:transparent" role="presentation" data-block-id="148"><tbody><tr><td style="min-width:100%;border-top:2px solid #3e4954" valign="top"></td></tr></tbody></table></td></tr><tr><td style="padding-top:20px;padding-bottom:0;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="76" class="mceText" id="dataBlockId-76" style="width:100%"><p><a href="https://www.allthingsdistributed.com/2024/02/reading-list-since-reinvent.html" target="_blank"><strong><span style="font-size: 20px">What I've Been Reading Since re:Invent</span></strong></a></p><p>— Werner Vogels</p><p><br/><strong>tl;dr</strong>: From the CTO at Amazon... “In the weeks that follow re:Invent, I try to make time to work through the ever-growing pile of books accumulating on my nightstand and throughout my office. It’s a losing battle. Then again, when was it ever worth doing something easy?” Werner provides a list of engineering and non-engineering content he recommends. </p><p><br/></p><p style="text-align: right;" class="last-child"><a href="http://www.pointer.io/tags/book-recommendation" target="_blank"><em><span style="font-size: 12px">BookRecommendation</span></em></a></p></div></td></tr><tr><td style="padding-top:0;padding-bottom:0;padding-right:15px;padding-left:0" class="mceBlockContainer" align="right" valign="top"><a href="mailto:?subject=What%20I've%20Been%20Reading%20Since%20re%3AInvent&body=I'm%20sharing%20this%20article%20I%20found%20on%20www.pointer.io%3A%0D%0A%0D%0AWhat%20I've%20Been%20Reading%20Since%20re%3AInvent%0D%0Ahttps%3A%2F%2Fwww.allthingsdistributed.com%2F2024%2F02%2Freading-list-since-reinvent.html%0D%0A" style="display:block" target="_blank" data-block-id="129"><img width="38" height="auto" style="border:0;width:38px;height:auto;max-width:64px !important;display:block" alt="" src="https://mcusercontent.com/e9492ff27d760c578a39d0675/images/5007b776-f11f-9e3f-6747-ec4408bb95b0.png" role="presentation" class="imageDropZone mceImage"/></a></td></tr><tr><td style="background-color:transparent;padding-top:5px;padding-bottom:5px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:transparent" role="presentation" data-block-id="136"><tbody><tr><td style="min-width:100%;border-top:2px solid #3e4954" valign="top"></td></tr></tbody></table></td></tr><tr><td style="padding-top:20px;padding-bottom:0;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="109" class="mceText" id="dataBlockId-109" style="width:100%"><p><a href="https://blog.gitbutler.com/git-tips-and-tricks/" target="_blank"><strong><span style="font-size: 20px">Git Tips And Tricks</span></strong></a></p><p>— Scott Chacon</p><p><br/><strong>tl;dr</strong>: “I’m going to write 3 short articles on some interesting Git things for intermediate to advanced Git users that you may not know, either because they just never came up or because they're pretty new and you've been using Git the same way for years. The topics are: (1) Oldies but goodies. (2) Some subtle new things. (3) Really large repositories and monorepos.”</p><p><br/></p><p style="text-align: right;" class="last-child"><a href="http://www.pointer.io/tags/git" target="_blank"><em><span style="font-size: 12px">Git</span></em></a></p></div></td></tr><tr><td style="padding-top:0;padding-bottom:0;padding-right:15px;padding-left:0" class="mceBlockContainer" align="right" valign="top"><a href="mailto:?subject=Git%20Tips%20And%20Tricks&body=I'm%20sharing%20this%20article%20I%20found%20on%20www.pointer.io%3A%0D%0A%0D%0AGit%20Tips%20And%20Tricks%0D%0Ahttps%3A%2F%2Fblog.gitbutler.com%2Fgit-tips-and-tricks%2F%0D%0A" style="display:block" target="_blank" data-block-id="152"><img width="38" height="auto" style="border:0;width:38px;height:auto;max-width:64px !important;display:block" alt="" src="https://mcusercontent.com/e9492ff27d760c578a39d0675/images/5007b776-f11f-9e3f-6747-ec4408bb95b0.png" role="presentation" class="imageDropZone mceImage"/></a></td></tr><tr><td style="background-color:transparent;padding-top:5px;padding-bottom:5px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:transparent" role="presentation" data-block-id="151"><tbody><tr><td style="min-width:100%;border-top:2px solid #3e4954" valign="top"></td></tr></tbody></table></td></tr><tr><td style="padding-top:20px;padding-bottom:0;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="155" class="mceText" id="dataBlockId-155" style="width:100%"><p><a href="https://martinfowler.com/articles/engineering-practices-llm.html" target="_blank"><strong><span style="font-size: 20px">Engineering Practices For LLM Application Development</span></strong></a></p><p>— David Tan, Jesse Wang</p><p><br/><strong>tl;dr</strong>: “LLM engineering involves much more than just prompt design or prompt engineering. In this article, we share a set of engineering practices that helped us deliver a prototype LLM application rapidly and reliably in a recent project. We'll share techniques for automated testing and adversarial testing of LLM applications, refactoring, as well as considerations for architecting LLM applications and responsible AI.”</p><p style="text-align: right;" class="last-child"><a href="http://www.pointer.io/tags/llm" target="_blank"><em><span style="font-size: 12px">LLM</span></em></a></p></div></td></tr><tr><td style="padding-top:0;padding-bottom:0;padding-right:15px;padding-left:0" class="mceBlockContainer" align="right" valign="top"><a href="mailto:?subject=Engineering%20Practices%20For%20LLM%20Application%20Development&body=I'm%20sharing%20this%20article%20I%20found%20on%20www.pointer.io%3A%0D%0A%0D%0AEngineering%20Practices%20For%20LLM%20Application%20Development%0D%0Ahttps%3A%2F%2Fmartinfowler.com%2Farticles%2Fengineering-practices-llm.html%0D%0A" style="display:block" target="_blank" data-block-id="157"><img width="38" height="auto" style="border:0;width:38px;height:auto;max-width:64px !important;display:block" alt="" src="https://mcusercontent.com/e9492ff27d760c578a39d0675/images/5007b776-f11f-9e3f-6747-ec4408bb95b0.png" role="presentation" class="imageDropZone mceImage"/></a></td></tr><tr><td style="background-color:transparent;padding-top:5px;padding-bottom:5px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:transparent" role="presentation" data-block-id="156"><tbody><tr><td style="min-width:100%;border-top:2px solid #3e4954" valign="top"></td></tr></tbody></table></td></tr><tr><td style="background-color:#3e4954;padding-top:20px;padding-bottom:20px;padding-right:0;padding-left:0" class="mceBlockContainer" valign="top"><div data-block-id="158" class="mceText" id="dataBlockId-158" style="width:100%"><p style="text-align: center;" class="last-child"><strong><span style="color:#ffffff;"><span style="font-size: 16px"><span style="font-family: 'Space Mono', 'Courier', Georgia, serif">Notable Links</span></span></span></strong></p></div></td></tr><tr><td style="padding-top:0;padding-bottom:0;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="98" class="mceText" id="dataBlockId-98" style="width:100%"><p><br/></p><p><a href="https://github.com/conductor-oss/conductor" target="_blank"><strong>Conductor</strong></a><strong>: </strong>Microservices orchestration engine.</p><p><br/></p><p><a href="https://github.com/apple/pkl" target="_blank"><strong>Pkl</strong></a><strong>: </strong>Configuration as code language.</p><p><br/></p><p><a href="https://github.com/reorproject/reor" target="_blank"><strong>Reor</strong></a><strong>: </strong>AI-powered desktop note-taking app.</p><p><br/></p><p><a href="https://github.com/servo/servo" target="_blank"><strong>Servo</strong></a><strong>: </strong>Web rendering engine written in Rust.</p><p><br/></p><p><a href="https://github.com/StractOrg/stract" target="_blank"><strong>Stract</strong></a><strong>: </strong>OS web search engine.</p><p class="last-child"><br/></p></div></td></tr><tr><td style="background-color:#3e4954;padding-top:0;padding-bottom:0;padding-right:0;padding-left:0" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:#3e4954" role="presentation" data-block-id="53"><tbody><tr><td style="min-width:100%;border-top:20px solid transparent" valign="top"></td></tr></tbody></table></td></tr><tr><td style="padding-top:20px;padding-bottom:20px;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><div data-block-id="89" class="mceText" id="dataBlockId-89" style="width:100%"><p style="text-align: center;">Click the below and shoot me an email!</p><p style="text-align: center;"><br/>1 = Didn't enjoy it all // 5 = Really enjoyed it</p><p style="text-align: center;"><br/></p><p style="text-align: center;" class="last-child"><a href="mailto:suraj@pointer.io?subject=Issue%20%23436%20-%20Score%3A%201&body=Here's%20why%3A"><strong>1</strong></a><strong> … </strong><a href="mailto:suraj@pointer.io?subject=Issue%20%23436%20-%20Score%3A%202&body=Here's%20why%3A"><strong>2</strong></a><strong> … </strong><a href="mailto:suraj@pointer.io?subject=Issue%20%23436%20-%20Score%3A%203&body=Here's%20why%3A"><strong>3</strong></a><strong> … </strong><a href="mailto:suraj@pointer.io?subject=Issue%20%23436%20-%20Score%3A%204&body=Here's%20Why%3A"><strong>4</strong></a><strong> … </strong><a href="mailto:suraj@pointer.io?subject=Issue%20%23436%20-%20Score%3A%205&body=Here's%20Why%3A"><strong>5</strong></a></p></div></td></tr><tr><td style="background-color:#3e4954;padding-top:0;padding-bottom:0;padding-right:0;padding-left:0" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:#3e4954" role="presentation" data-block-id="90"><tbody><tr><td style="min-width:100%;border-top:20px solid transparent" valign="top"></td></tr></tbody></table></td></tr><tr><td style="padding-top:0;padding-bottom:0;padding-right:0;padding-left:0" class="mceLayoutContainer" valign="top"><table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation" data-block-id="11" id="section_b62879b82df5c2d1465c41d55fbc325e" class="mceFooterSection"><tbody><tr class="mceRow"><td style="background-position:center;background-repeat:no-repeat;background-size:cover" valign="top"><table border="0" cellpadding="0" cellspacing="12" width="100%" role="presentation"><tbody><tr><td style="padding-top:0;padding-bottom:0;margin-bottom:12px" class="mceColumn" data-block-id="-3" valign="top" colspan="12" width="100%"><table border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation"><tbody><tr><td style="padding-top:20px;padding-bottom:20px;padding-right:20px;padding-left:20px" class="mceBlockContainer" align="center" valign="top"><div data-block-id="9" class="mceText" id="dataBlockId-9" style="display:inline-block;width:100%"><p class="last-child"><span style="font-size: 12px"><span style="font-family: 'Space Mono', 'Courier', Georgia, serif">Pointer is emailed twice a week on Tuesdays and Fridays @ 9am EST.<br/><br/></span></span><a href="https://pointer.us9.list-manage.com/unsubscribe?u=e9492ff27d760c578a39d0675&id=6ba2b83261&t=b&e=[UNIQID]&c=01b4cdda41"><span style="text-decoration:underline;"><span style="font-size: 12px"><span style="font-family: 'Space Mono', 'Courier', Georgia, serif">Unsubscribe</span></span></span></a><span style="font-size: 12px"><span style="font-family: 'Space Mono', 'Courier', Georgia, serif"> // </span></span><a href="https://www.pointer.io/sponsorship/" target="_blank"><span style="text-decoration:underline;"><span style="font-size: 12px"><span style="font-family: 'Space Mono', 'Courier', Georgia, serif">Sponsorship</span></span></span></a><span style="color:rgb(32, 32, 32);"><span style="text-decoration:underline;"><span style="font-size: 12px"><span><br/></span></span></span></span></p></div></td></tr><tr><td class="mceLayoutContainer" align="center" valign="top"><table align="center" border="0" cellpadding="0" cellspacing="0" width="100%" role="presentation" data-block-id="-2"><tbody><tr class="mceRow"><td style="background-position:center;background-repeat:no-repeat;background-size:cover;padding-top:0px;padding-bottom:0px" valign="top"><table border="0" cellpadding="0" cellspacing="24" width="100%" role="presentation"><tbody></tbody></table></td></tr></tbody></table></td></tr></tbody></table></td></tr></tbody></table></td></tr></tbody></table></td></tr><tr><td style="background-color:transparent;padding-top:0;padding-bottom:0;padding-right:20px;padding-left:20px" class="mceBlockContainer" valign="top"><table border="0" cellpadding="0" cellspacing="0" width="100%" style="background-color:transparent" role="presentation" data-block-id="75"><tbody><tr><td style="min-width:100%;border-top:2px dotted #000000" valign="top"></td></tr></tbody></table></td></tr></tbody></table></td></tr></tbody></table></td></tr></tbody></table></td></tr></tbody></table><!--[if (gte mso 9)|(IE)]></td></tr></table><![endif]--></td></tr></tbody></table>
+</td>
+</tr>
+</tbody></table>
+</center>
+</body></html></div>
+	</div>
+</div>
+
+
+    
+    
+  </body>
+</html>

--- a/tests/fixtures/ee9c973edf.html
+++ b/tests/fixtures/ee9c973edf.html
@@ -1,0 +1,1477 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Essential Reading For Engineering Leaders. Handpicked articles summarized into a 5‑minute read.">
+    <meta name="author" content="Suraj Kapoor">
+
+    <meta property="og:title" content="Essential Reading For Engineering Leaders"/>
+    <meta property="og:image" content="http://www.pointer.io/static/images/social-og.png"/>
+    <meta property="og:description" content="Handpicked articles summarized into a 5‑minute read."/>
+    <meta property="og:url" content="www.pointer.io"/>
+
+    <title>Pointer | Essential Reading For Engineering Leaders</title>
+
+    <link href="/static/css/main.css" rel="stylesheet">
+
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/static/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/static/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/static/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/static/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/static/safari-pinned-tab.svg"
+      color="#101720"
+    />
+    <meta name="msapplication-TileColor" content="#101720" />
+    <meta name="theme-color" content="#f3f4f6" />
+    
+    <script>
+	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+	  ga('create', 'UA-54273473-3', 'auto');
+	  ga('send', 'pageview');
+   </script>
+
+<!-- Google tag (gtag.js) -->
+   <script async src="https://www.googletagmanager.com/gtag/js?id=G-4MC7M40CEQ"></script>
+   <script>
+   window.dataLayer = window.dataLayer || [];
+   function gtag(){dataLayer.push(arguments);}
+   gtag('js', new Date());
+
+   gtag('config', 'G-4MC7M40CEQ');
+   </script>
+
+    <script>
+      !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+      posthog.init('phc_4ok8ZC2gD3gA0aIQ0jYS4RliamTWKPVuL4kNsmbQX94',{api_host:'https://us.i.posthog.com'})
+    </script>
+
+
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P9R9NX9');</script>
+  <!-- End Google Tag Manager -->
+
+
+  <!-- Facebook Pixel Code -->
+  <script>
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '6476529382457682');
+  fbq('track', 'PageView');
+  </script>
+  <noscript><img height="1" width="1" style="display:none"
+  src="https://www.facebook.com/tr?id=370244158087974&ev=PageView&noscript=1"
+  /></noscript>
+  <!-- End Facebook Pixel Code -->
+
+  <!-- Reddit Pixel --><script>!function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);rdt('init','t2_einsuv7w');rdt('track', 'PageVisit');</script><!-- DO NOT MODIFY --><!-- End Reddit Pixel -->
+  
+  </head>
+  <body class="flex flex-col bg-blue-950 font-grotesk text-gray-200">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P9R9NX9" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
+    <header class="bg-blue-950">
+      <nav
+        class="mx-auto flex items-center justify-between border-b border-blue-900/50 px-6 py-4 shadow-sm lg:px-8"
+        aria-label="Global"
+      >
+        <a href="/" class="-m-1.5 p-1.5 text-inherit">
+          <svg
+            clip-rule="evenodd"
+            fill-rule="evenodd"
+            stroke-linejoin="round"
+            stroke-miterlimit="2"
+            viewBox="0 0 334 69"
+            xmlns="http://www.w3.org/2000/svg"
+            class="max-h-full w-32 fill-gray-100"
+          >
+            <path
+              d="m425.633 1384.78-27.63-27.63-12.49-28.01-6.056 2.65 10.597 27.63v40.12h-36.335v-40.12l10.598-27.63-6.056-2.65-12.49 28.01-27.63 27.63-25.359-25.36 27.63-27.63 28.008-12.49-2.649-6.05-27.63 10.59h-40.121v-36.33h40.121l27.63 10.6 2.649-6.06-28.008-12.49-27.63-27.63 25.359-25.36 27.63 27.63 12.49 28.01 6.056-2.65-10.598-27.63v-40.12h36.335v40.12l-10.597 27.63 6.056 2.65 12.49-28.01 27.63-27.63 25.359 25.36-27.63 27.63-28.009 12.49 2.65 6.06 27.63-10.6h40.12v36.33h-40.12l-27.63-10.59-2.65 6.05 28.009 12.49 27.63 27.63z"
+              fill-rule="nonzero"
+              transform="matrix(.119681 0 0 .119681 71.822 -145.03)"
+            />
+            <g
+              transform="matrix(.210802 0 0 .210802 -157.384 -236.08)"
+            >
+              <path
+                d="m796.556 1338.23v99.92h-49.961v-264.95h103.707c13.626 0 25.485 2.21 35.578 6.63 10.094 4.41 18.484 10.22 25.17 17.41 6.687 7.19 11.734 15.39 15.14 24.6s5.11 18.61 5.11 28.2v9.08c0 9.84-1.704 19.49-5.11 28.96-3.406 9.46-8.453 17.91-15.14 25.35-6.686 7.45-15.076 13.44-25.17 17.98-10.093 4.54-21.952 6.82-35.578 6.82zm0-47.69h48.826c11.102 0 19.871-3.03 26.305-9.09 6.434-6.05 9.652-13.88 9.652-23.46v-4.55c0-9.58-3.218-17.41-9.652-23.46-6.434-6.06-15.203-9.09-26.305-9.09h-48.826z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1164.45 1346.55c0 15.65-2.65 29.46-7.95 41.45-5.3 11.98-12.49 22.08-21.57 30.28s-19.49 14.44-31.23 18.73c-11.73 4.29-24.03 6.44-36.9 6.44s-25.17-2.15-36.9-6.44c-11.74-4.29-22.15-10.53-31.229-18.73-9.083-8.2-16.275-18.3-21.574-30.28-5.299-11.99-7.948-25.8-7.948-41.45v-4.54c0-15.39 2.649-29.08 7.948-41.07 5.299-11.98 12.491-22.14 21.574-30.46 9.079-8.33 19.489-14.64 31.229-18.93 11.73-4.29 24.03-6.43 36.9-6.43s25.17 2.14 36.9 6.43c11.74 4.29 22.15 10.6 31.23 18.93 9.08 8.32 16.27 18.48 21.57 30.46 5.3 11.99 7.95 25.68 7.95 41.07zm-97.65 51.48c6.81 0 13.25-1.14 19.3-3.41 6.06-2.27 11.36-5.55 15.9-9.84s8.14-9.52 10.79-15.71c2.65-6.18 3.97-13.18 3.97-21v-7.57c0-7.83-1.32-14.83-3.97-21.01s-6.25-11.42-10.79-15.71-9.84-7.57-15.9-9.84c-6.05-2.27-12.49-3.4-19.3-3.4s-13.25 1.13-19.3 3.4c-6.06 2.27-11.36 5.55-15.9 9.84s-8.14 9.53-10.79 15.71-3.97 13.18-3.97 21.01v7.57c0 7.82 1.32 14.82 3.97 21 2.65 6.19 6.25 11.42 10.79 15.71s9.84 7.57 15.9 9.84c6.05 2.27 12.49 3.41 19.3 3.41z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1215.55 1392.73h63.58v-96.89h-59.04v-45.43h106.74v142.32h54.5v45.42h-165.78z"
+              />
+              <path
+                d="m1491.47 1438.15h-47.69v-187.74h47.69v28.01h6.81c4.29-10.59 11.23-18.8 20.82-24.6s20.82-8.7 33.69-8.7c9.08 0 17.59 1.45 25.54 4.35s14.95 7.38 21.01 13.44c6.06 6.05 10.79 13.75 14.19 23.08 3.41 9.34 5.11 20.44 5.11 33.31v118.85h-47.69v-106.74c0-13.37-3.21-23.9-9.65-31.6-6.43-7.7-15.71-11.54-27.82-11.54-14.13 0-24.66 4.73-31.6 14.19s-10.41 22.14-10.41 38.04z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1670.12 1250.41h55.64v-77.21h47.69v77.21h67.75v45.43h-67.75v85.53c0 7.57 3.4 11.36 10.22 11.36h50.71v45.42h-79.48c-8.58 0-15.58-2.78-21.01-8.33-5.42-5.55-8.13-12.62-8.13-21.2v-112.78h-55.64z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1949.07 1359.8c.25 5.55 1.57 10.66 3.97 15.33s5.68 8.7 9.84 12.11c4.17 3.41 8.96 6.06 14.39 7.95 5.42 1.89 11.16 2.84 17.22 2.84 11.86 0 20.94-2.08 27.25-6.25 6.31-4.16 10.85-9.14 13.62-14.95l40.88 22.71c-2.27 4.8-5.42 9.78-9.46 14.95s-9.27 9.91-15.71 14.2c-6.43 4.29-14.25 7.82-23.46 10.59-9.22 2.78-20 4.17-32.37 4.17-14.13 0-26.99-2.27-38.6-6.82-11.61-4.54-21.64-11.1-30.09-19.68-8.46-8.58-15.02-19.05-19.68-31.41-4.67-12.37-7.01-26.37-7.01-42.01v-2.28c0-14.38 2.46-27.5 7.38-39.36s11.67-21.95 20.25-30.28 18.61-14.82 30.09-19.49c11.49-4.67 23.79-7 36.91-7 16.15 0 30.02 2.83 41.63 8.51s21.2 12.87 28.77 21.58c7.57 8.7 13.12 18.29 16.65 28.76s5.3 20.63 5.3 30.47v25.36zm45.04-71.53c-12.11 0-21.95 3.09-29.52 9.27s-12.49 13.31-14.76 21.38h88.56c-1.51-8.83-6.24-16.15-14.19-21.95s-17.98-8.7-30.09-8.7z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m2129.61 1250.41h79.48v27.26h6.82c3.53-10.35 9.52-18.36 17.97-24.04 8.46-5.68 18.61-8.51 30.47-8.51 18.68 0 33.69 5.86 45.04 17.6 11.36 11.73 17.04 29.58 17.04 53.55v8.33l-49.21 4.54v-5.3c0-10.34-2.65-18.61-7.95-24.79s-13.24-9.27-23.84-9.27-18.93 3.66-24.98 10.98c-6.06 7.31-9.09 17.78-9.09 31.41v60.56h43.15v45.42h-129.44v-45.42h38.6v-96.89h-34.06z"
+                fill-rule="nonzero"
+              />
+            </g>
+          </svg>
+        </a>
+        <div class="flex gap-x-12">
+          
+        </div>
+      </nav>
+    </header>
+    
+
+<div class="bg-white">
+	<div class="w-[670px] max-w-full m-auto py-8">
+		<div class="pb-2 px-1">
+			<h1 class="m-0 text-2xl text-gray-950 font-bold">Issue #169</h1>
+			<time datetime="2020-01-16 14:00:00" class="mt-0 text-gray-500">January 16, 2020</time>
+			<div class="flex justify-between text-center py-2">
+				
+					<a href="/archives/7c4040cadf" class="inline-block mt-3 w-1/4 flex-none rounded-md bg-yellow-300 px-3.5 py-3 text-sm font-bold text-gray-900 shadow-sm hover:bg-yellow-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-300">&laquo; Prev</a>
+				
+				
+					<a href="/archives/b25026a5a6" class="inline-block mt-3 w-1/4 flex-none rounded-md bg-yellow-300 px-3.5 py-3 text-sm font-bold text-gray-900 shadow-sm hover:bg-yellow-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-300">Next &raquo;</a>
+				
+			</div>
+		</div>
+		<div class="text-transparent"><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <head>
+        <!-- NAME: SIMPLE TEXT -->
+        <meta name="viewport" content="width=device-width">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <title>Issue #169</title>
+        
+    <style type="text/css">
+		p{
+			margin:1em 0;
+		}
+		table{
+			border-collapse:collapse;
+		}
+		img,a img{
+			border:0;
+			outline:none;
+			text-decoration:none;
+		}
+		h1,h2,h3,h4,h5,h6{
+			display:block;
+			margin:0;
+			padding:0;
+		}
+		body,#bodyTable,#bodyCell{
+			height:100% !important;
+			margin:0;
+			padding:0;
+			width:100% !important;
+		}
+		.mcnPreviewText{
+			display:none !important;
+		}
+		#outlook a{
+			padding:0;
+		}
+		img{
+			-ms-interpolation-mode:bicubic;
+		}
+		.ReadMsgBody{
+			width:100%;
+		}
+		.ExternalClass{
+			width:100%;
+		}
+		td,table{
+			mso-table-lspace:0pt;
+			mso-table-rspace:0pt;
+		}
+		p,a,li,td,body,table,blockquote{
+			-ms-text-size-adjust:100%;
+			-webkit-text-size-adjust:100%;
+		}
+		.ExternalClass,.ExternalClass p,.ExternalClass td,.ExternalClass div,.ExternalClass span,.ExternalClass font{
+			line-height:100%;
+		}
+		#templateHeader,#templateBody,#templateFooter{
+			min-width:100%;
+		}
+		a.mcnButton{
+			display:block;
+		}
+		.mcnImage,.mcnRetinaImage{
+			vertical-align:bottom;
+		}
+		.mcnTextContent img{
+			height:auto !important;
+		}
+		body,#bodyTable{
+			background-color:#FFFFFF;
+		}
+		#bodyCell{
+			border-top:0;
+		}
+		#templateContainer{
+			border:0;
+		}
+		h1{
+			color:#202020 !important;
+			font-family:Helvetica;
+			font-size:24px;
+			font-style:normal;
+			font-weight:bold;
+			line-height:125%;
+			letter-spacing:normal;
+			text-align:left;
+		}
+		h2{
+			color:#202020 !important;
+			font-family:Helvetica;
+			font-size:20px;
+			font-style:normal;
+			font-weight:bold;
+			line-height:125%;
+			letter-spacing:-.75px;
+			text-align:left;
+		}
+		h3{
+			color:#202020 !important;
+			font-family:Helvetica;
+			font-size:18px;
+			font-style:normal;
+			font-weight:bold;
+			line-height:125%;
+			letter-spacing:normal;
+			text-align:left;
+		}
+		h4{
+			color:#202020 !important;
+			font-family:Helvetica;
+			font-size:16px;
+			font-style:normal;
+			font-weight:bold;
+			line-height:125%;
+			letter-spacing:normal;
+			text-align:left;
+		}
+		#templateHeader{
+			border-bottom:0;
+		}
+		.headerContainer .mcnTextContent,.headerContainer .mcnTextContent p{
+			color:#000000;
+			font-family:Helvetica;
+			font-size:10px;
+			line-height:100%;
+			text-align:left;
+		}
+		.headerContainer .mcnTextContent a{
+			color:#202020;
+			font-weight:normal;
+			text-decoration:underline;
+		}
+		#templateBody{
+			border-top:0;
+			border-bottom:0;
+		}
+		.bodyContainer .mcnTextContent,.bodyContainer .mcnTextContent p{
+			color:#202020;
+			font-family:Helvetica;
+			font-size:15px;
+			line-height:150%;
+			text-align:left;
+		}
+		.bodyContainer .mcnTextContent a{
+			color:#202020;
+			font-weight:normal;
+			text-decoration:none;
+		}
+		#templateFooter{
+			border-top:0;
+		}
+		.footerContainer .mcnTextContent,.footerContainer .mcnTextContent p{
+			color:#202020;
+			font-family:Helvetica;
+			font-size:11px;
+			line-height:125%;
+			text-align:left;
+		}
+		.footerContainer .mcnTextContent a{
+			color:#202020;
+			font-weight:normal;
+			text-decoration:underline;
+		}
+	@media only screen and (max-width:480px){
+		body{
+			width:100% !important;
+			min-width:100% !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		.mcnRetinaImage{
+			max-width:100% !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		td[class=footerContainer] a[class=utilityLink]{
+			display:block !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		td[class=mcnImageGroupContent]{
+			padding:9px !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		td[class=mcnImageCardBottomImageContent]{
+			padding-bottom:9px !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		table[class=mcpreview-image-uploader]{
+			display:none !important;
+			width:100% !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		td[class=mcnImageGroupBlockInner]{
+			padding-top:0 !important;
+			padding-bottom:0 !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		tbody[class=mcnImageGroupBlockOuter]{
+			padding-top:9px !important;
+			padding-bottom:9px !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		td[class=mcnTextContent],td[class=mcnBoxedTextContentColumn]{
+			padding-right:18px !important;
+			padding-left:18px !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		table[class=mcnCaptionLeftContentOuter] td[class=mcnTextContent],table[class=mcnCaptionRightContentOuter] td[class=mcnTextContent]{
+			padding-top:9px !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		td[class=mcnImageCardLeftImageContent],td[class=mcnImageCardRightImageContent]{
+			padding-right:18px !important;
+			padding-bottom:0 !important;
+			padding-left:18px !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		img[class=mcnImage],table[class=mcnCaptionTopContent],table[class=mcnCaptionBottomContent],table[class=mcnTextContentContainer],table[class=mcnImageGroupContentContainer],table[class=mcnCaptionLeftTextContentContainer],table[class=mcnCaptionRightTextContentContainer],table[class=mcnCaptionLeftImageContentContainer],table[class=mcnCaptionRightImageContentContainer],table[class=mcnImageCardLeftTextContentContainer],table[class=mcnImageCardRightTextContentContainer],table[class=socialContainer],.mcnImageCardLeftImageContentContainer,.mcnImageCardRightImageContentContainer{
+			width:100% !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		.mcnBoxedTextContentContainer{
+			max-width:100% !important;
+			min-width:100% !important;
+			width:100% !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		table[id=templateContainer],table[id=templatePreheader],table[id=templateHeader],table[id=templateBody],table[id=templateFooter]{
+			max-width:600px !important;
+			width:100% !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		h1{
+			font-size:24px !important;
+			line-height:125% !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		h2{
+			font-size:20px !important;
+			line-height:125% !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		h3{
+			font-size:18px !important;
+			line-height:125% !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		h4{
+			font-size:16px !important;
+			line-height:125% !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		td[class=headerContainer] td[class=mcnTextContent],td[class=headerContainer] td[class=mcnTextContent] p{
+			font-size:18px !important;
+			line-height:125% !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		td[class=bodyContainer] td[class=mcnTextContent],td[class=bodyContainer] td[class=mcnTextContent] p{
+			font-size:18px !important;
+			line-height:125% !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		td[class=footerContainer] td[class=mcnTextContent],td[class=footerContainer] td[class=mcnTextContent] p{
+			font-size:14px !important;
+			line-height:115% !important;
+		}
+
+}	@media only screen and (max-width:480px){
+		table[class=mcnBoxedTextContentContainer] td[class=mcnTextContent],td[class=mcnBoxedTextContentContainer] td[class=mcnTextContent] p{
+			font-size:18px !important;
+			line-height:125% !important;
+		}
+
+}</style></head>
+    <body style="margin: 0;padding: 0;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;background-color: #FFFFFF;height: 100% !important;width: 100% !important;">
+        <!---->
+        <!--[if !gte mso 9]><!----><span class="mcnPreviewText" style="display:none; font-size:0px; line-height:0px; max-height:0px; max-width:0px; opacity:0; overflow:hidden; visibility:hidden; mso-hide:all;">A Reading Club For Software Developers</span><!--<![endif]-->
+        <!---->
+        <center>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="bodyTable" style="border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;margin: 0;padding: 0;background-color: #FFFFFF;height: 100% !important;width: 100% !important;">
+                <tr>
+                    <td align="left" valign="top" id="bodyCell" style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;margin: 0;padding: 0;border-top: 0;height: 100% !important;width: 100% !important;">
+                        <!-- BEGIN TEMPLATE // -->
+                        <table border="0" cellpadding="0" cellspacing="0" width="600" id="templateContainer" style="border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;border: 0;">
+                            <tr>
+                                <td align="left" valign="top" style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                                    <!-- BEGIN HEADER // -->
+                                    <table border="0" cellpadding="0" cellspacing="0" width="600" id="templateHeader" style="border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;min-width: 100%;border-bottom: 0;">
+                                        <tr>
+                                            <td valign="top" class="headerContainer" style="padding-top: 9px;padding-bottom: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;"><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnDividerBlockOuter">
+        <tr>
+            <td class="mcnDividerBlockInner" style="min-width: 100%;padding: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 2px solid #EAEAEA;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody><tr>
+                        <td style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnButtonBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnButtonBlockOuter">
+        <tr>
+            <td style="padding-top: 0;padding-right: 18px;padding-bottom: 18px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" valign="top" align="center" class="mcnButtonBlockInner">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnButtonContentContainer" style="border-collapse: separate !important;border-radius: 0px;background-color: #000000;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody>
+                        <tr>
+                            <td align="center" valign="middle" class="mcnButtonContent" style="font-family: &quot;Courier New&quot;, Courier, &quot;Lucida Sans Typewriter&quot;, &quot;Lucida Typewriter&quot;, monospace;font-size: 12px;padding: 10px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                                <a class="mcnButton " title="Pointer.io" href="http://www.pointer.io" target="_blank" style="font-weight: bold;letter-spacing: normal;line-height: 100%;text-align: center;text-decoration: none;color: #FFFFFF;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;display: block;">Pointer.io</a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #000000;font-family: Helvetica;font-size: 10px;line-height: 100%;text-align: left;">
+                        
+                            <div style="text-align: center;"><span style="font-size:16px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">A Reading Club For Software Developers -&nbsp;<a href="https://www.pointer.io/" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: underline;">Sign Up Here</a></span></span></div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table></td>
+                                        </tr>
+                                    </table>
+                                    <!-- // END HEADER -->
+                                </td>
+                            </tr>
+                            <tr>
+                                <td align="left" valign="top" style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                                    <!-- BEGIN BODY // -->
+                                    <table border="0" cellpadding="0" cellspacing="0" width="600" id="templateBody" style="border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;min-width: 100%;border-top: 0;border-bottom: 0;">
+                                        <tr>
+                                            <td valign="top" class="bodyContainer" style="padding-top: 9px;padding-bottom: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;"><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnDividerBlockOuter">
+        <tr>
+            <td class="mcnDividerBlockInner" style="min-width: 100%;padding: 0px 18px 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 3px solid #000000;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody><tr>
+                        <td style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+                        
+                            <div><span style="font-size:18px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><a href="https://overreacted.io/goodbye-clean-code/" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: none;"><strong>Goodbye, Clean Code</strong></a></u></span></span></div>
+
+<div>
+<div><span style="font-size:16px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">- Dan Abramov</span></span></div>
+
+<div style="text-align: right;"><em><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:14px">#CareerAdvice #PracticalTips</span></span></em></div>
+
+<div>&nbsp;</div>
+
+<div><u style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace; font-size:14px"><strong>tl;dr</strong></u><font face="courier new, courier, lucida sans typewriter, lucida typewriter, monospace"><span style="font-size:14px">: Developers strive for cleaner code. There's an inflection point when a developer starts writing&nbsp;code in abstraction, this feels like a "super power." Dan learnt this comes with its own trade-offs. "Clean code is not a goal."</span></font></div>
+</div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnDividerBlockOuter">
+        <tr>
+            <td class="mcnDividerBlockInner" style="min-width: 100%;padding: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 3px solid #000000;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody><tr>
+                        <td style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+                        
+                            <div><span style="font-size:18px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><a href="https://www.alexhudson.com/2020/01/13/the-no-code-delusion/" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: none;"><strong>The "No Code" Delusion</strong></a></u></span></span></div>
+
+<div>
+<div><span style="font-size:16px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">- Alex Hudson</span></span></div>
+
+<div style="text-align: right;"><em><span style="font-size:14px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">#ThoughtPiece #IndustryTrend&nbsp;</span></span></em></div>
+
+<div>&nbsp;</div>
+
+<div><span style="font-size:14px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><strong>tl;dr</strong></u>: Alex considers the "no code" discussions&nbsp;a&nbsp;"pipe dream," not seeing any tangible evidence.&nbsp;Certain tools have replaced software e.g. Zapier. With software, the "devil is in the details" and that cannot be replicated.&nbsp;</span></span></div>
+</div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnDividerBlockOuter">
+        <tr>
+            <td class="mcnDividerBlockInner" style="min-width: 100%;padding: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 3px solid #000000;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody><tr>
+                        <td style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+                        
+                            <div><span style="font-size:18px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><a href="https://avc.com/2020/01/the-crucible-of-leadership/" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: none;"><strong>The Crucible Of Leadership</strong></a></u></span></span></div>
+
+<div>
+<div><span style="font-size:16px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">-&nbsp;Jerry Colonna</span></span></div>
+
+<div style="text-align: right;"><em><span style="font-size:14px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">#Management #Leadership</span></span></em></div>
+
+<div>&nbsp;</div>
+
+<div><span style="font-size:14px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><strong>tl;dr</strong></u>: Leaders are often created through a "rite of passage," a moment coined the crucible. "The magic, the alchemy, occurs when what we do&nbsp;mixes with&nbsp;who we are and is cooked by the heat of&nbsp;what we believe." Unpacking that, knowing who you are is critical to leadership.</span></span></div>
+</div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnDividerBlockOuter">
+        <tr>
+            <td class="mcnDividerBlockInner" style="min-width: 100%;padding: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 3px solid #000000;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody><tr>
+                        <td style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+                        
+                            <div><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:18px"><u><a href="https://mkaz.blog/misc/notes-on-technical-writing/" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: none;"><strong>Notes On Technical Writing</strong></a></u></span><br>
+<span style="font-size:16px">-&nbsp;Marcus Kazmierczak</span></span></div>
+
+<div>
+<div style="text-align: right;"><em><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:14px">#Documentation #PracticalTips</span></span></em></div>
+
+<div>&nbsp;</div>
+
+<div><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:14px"><u><strong>tl;dr</strong></u>:&nbsp;Marcus frequently writes documentation for Wordpress. Here, he guides us through some of his learnings, including the concept of&nbsp;Minimalist Instruction.&nbsp;</span></span></div>
+</div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnDividerBlockOuter">
+        <tr>
+            <td class="mcnDividerBlockInner" style="min-width: 100%;padding: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 3px solid #000000;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody><tr>
+                        <td style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+                        
+                            <div><span style="font-size:18px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><a href="https://medium.com/@ssg/how-is-computer-programming-different-today-than-20-years-ago-9d0154d1b6ce" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: none;"><strong>How Is Computer Programming Different Today Than 20 Years Ago?</strong></a></u></span></span></div>
+
+<div>
+<div><span style="font-size:16px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">-&nbsp;Sedat Kapanoglu</span></span></div>
+
+<div style="text-align: right;"><span style="font-size:14px"><em><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">#IndustryTrend</span></em></span></div>
+
+<div>&nbsp;</div>
+
+<div><span style="font-size:14px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><strong>tl;dr</strong></u>: A laundry list of changes seen by Sedat, including this - "being a software development team now involves all team members performing a mysterious ritual of standing up together for 15 minutes in the morning and drawing occult symbols with post-its."<br>
+<br>
+You can bypass the paywall by clicking the <a href="https://twitter.com/esesci/status/1215093488884125697" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: none;"><u>link in this tweet</u>.</a></span></span></div>
+</div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnDividerBlockOuter">
+        <tr>
+            <td class="mcnDividerBlockInner" style="min-width: 100%;padding: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 3px solid #000000;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody><tr>
+                        <td style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+                        
+                            <div><span style="font-size:18px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><a href="https://ovid.github.io/articles/database-design-standards.html" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: none;"><strong>Database Design Standards</strong></a></u></span></span></div>
+
+<div>
+<div><span style="font-size:16px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">- Curtis Poe</span></span></div>
+
+<div style="text-align: right;"><em><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:14px">#Database #Guides #PracticalTips</span></span></em></div>
+
+<div>&nbsp;</div>
+
+<div><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:14px"><u><strong>tl;dr</strong></u>: Curtis runs through some tips on database design - whether to go with camel case names or underscore_names, plural or singular tables, column naming, and more.&nbsp;</span></span></div>
+</div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnDividerBlockOuter">
+        <tr>
+            <td class="mcnDividerBlockInner" style="min-width: 100%;padding: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 3px solid #000000;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody><tr>
+                        <td style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnBoxedTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <!--[if gte mso 9]>
+	<table align="center" border="0" cellspacing="0" cellpadding="0" width="100%">
+	<![endif]-->
+	<tbody class="mcnBoxedTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnBoxedTextBlockInner" style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                
+				<!--[if gte mso 9]>
+				<td align="center" valign="top" ">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" class="mcnBoxedTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td style="padding-top: 9px;padding-left: 18px;padding-bottom: 9px;padding-right: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                        
+                            <table border="0" cellspacing="0" class="mcnTextContentContainer" width="100%" style="min-width: 100% !important;background-color: #3E4954;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                                <tbody><tr>
+                                    <td valign="top" class="mcnTextContent" style="padding: 18px;color: #FFFFFF;font-family: Helvetica;font-size: 14px;font-weight: normal;text-align: center;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;line-height: 150%;">
+                                        <div style="text-align: center;"><span style="font-size:16px"><strong><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">"Before software can be reusable,<br>
+it first has to be usable."</span></strong></span><br>
+&nbsp;</div>
+
+<div style="text-align: center;"><span style="font-size:16px"><strong><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">– Ralph Johnson</span></strong></span></div>
+
+                                    </td>
+                                </tr>
+                            </tbody></table>
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if gte mso 9]>
+				</td>
+				<![endif]-->
+                
+				<!--[if gte mso 9]>
+                </tr>
+                </table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnDividerBlockOuter">
+        <tr>
+            <td class="mcnDividerBlockInner" style="min-width: 100%;padding: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 3px solid #000000;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody><tr>
+                        <td style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+                        
+                            <div><span style="font-size:18px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><a href="https://medium.com/@rinaarts/radical-candor-software-edition-d4b5ad401be3" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: none;"><strong>Radical Candor: Software Edition</strong></a></u></span></span></div>
+
+<div>
+<div><span style="font-size:16px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">-&nbsp;Rina Artstain</span></span></div>
+
+<div style="text-align: right;"><em><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:14px">#Management #CodeReview</span></span></em></div>
+
+<div>&nbsp;</div>
+
+<div><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:14px"><u><strong>tl;dr</strong></u>:&nbsp;A management&nbsp;style of communication that's "kind and clear, specific and sincere" is applied to both design and code reviews here.&nbsp;&nbsp;<br>
+<br>
+You can bypass the paywall by clicking the <u><a href="https://twitter.com/rinaarts/status/1214297533146652672" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: none;">link in this tweet</a></u>.</span></span></div>
+</div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnDividerBlockOuter">
+        <tr>
+            <td class="mcnDividerBlockInner" style="min-width: 100%;padding: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 3px solid #000000;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody><tr>
+                        <td style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+                        
+                            <div><span style="font-size:18px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><a href="https://blog.chromium.org/2020/01/building-more-private-web-path-towards.html" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: none;"><strong>Building A&nbsp;More Private Web: A Path Towards Making Third Party Cookies Obsolete</strong></a></u></span></span></div>
+
+<div>
+<div><span style="font-size:16px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">- Justin Schuh</span></span></div>
+
+<div style="text-align: right;"><em><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:14px">#Chrome #Cookies</span></span></em></div>
+
+<div>&nbsp;</div>
+
+<div><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:14px"><u><strong>tl;dr</strong></u>: Within 2 years, Chrome plans to phase out 3rd party cookies and maintain a healthy ad-supported web, using open-standard mechanisms like the Privacy Sandbox.</span></span></div>
+</div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnDividerBlockOuter">
+        <tr>
+            <td class="mcnDividerBlockInner" style="min-width: 100%;padding: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 3px solid #000000;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody><tr>
+                        <td style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+                        
+                            <div><span style="font-size:18px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><a href="https://codahale.com/work-is-work/" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: none;"><strong>Work Is Work</strong></a></u></span></span></div>
+
+<div>
+<div><span style="font-size:16px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">-&nbsp;Coda Hale&nbsp;</span></span></div>
+
+<div style="text-align: right;"><em><span style="font-size:14px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">&nbsp;#OrganizationalDesign #ManagementProcess #Scaling</span></span></em></div>
+
+<div>&nbsp;</div>
+
+<div><span style="font-size:14px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><strong>tl;dr</strong></u>: Org design is fetishized by corporate America&nbsp;always looking for some hack. There isn't one. Organizations are imperfect and, at very best, scale linearly. Despite that, there are tips on how to design a scaling organization here.&nbsp;</span></span></div>
+</div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnDividerBlockOuter">
+        <tr>
+            <td class="mcnDividerBlockInner" style="min-width: 100%;padding: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 3px solid #000000;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody><tr>
+                        <td style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+                        
+                            <div><span style="font-size:18px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><a href="https://m.signalvnoise.com/aws-s3-youre-out-of-order/" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: none;"><strong>AWS S3: You’re Out Of Order</strong></a></u></span></span></div>
+
+<div>
+<div><span style="font-size:16px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">-&nbsp;John Williams</span></span></div>
+
+<div style="text-align: right;"><em><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:14px">#AWS #Packets</span></span></em></div>
+
+<div>&nbsp;</div>
+
+<div><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:14px"><u><strong>tl;dr</strong></u>: Seeing delays in large uploads to AWS, John discovered thousands of out-of-order packets causing retransmissions. When told this, AWS said that “out-of-order packets are not a bug." He discusses how the issue was fixed.</span></span></div>
+</div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnDividerBlockOuter">
+        <tr>
+            <td class="mcnDividerBlockInner" style="min-width: 100%;padding: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 3px solid #000000;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody><tr>
+                        <td style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+                        
+                            <div><span style="font-size:18px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><a href="https://gregoryszorc.com/blog/2020/01/13/mercurial's-journey-to-and-reflections-on-python-3/" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: none;"><strong>Mercurial's Journey To And Reflections On Python 3</strong></a></u></span></span></div>
+
+<div>
+<div><span style="font-size:16px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">-&nbsp;Gregory Szorc</span></span></div>
+
+<div style="text-align: right;"><em><span style="font-size:14px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace">#Python</span></span></em></div>
+
+<div>&nbsp;</div>
+
+<div><span style="font-size:14px"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><u><strong>tl;dr</strong></u>: Divided into two parts, the first are&nbsp;the objective steps taken to migrate to Python 3.&nbsp;The second is the authors opinions. "For Mercurial, Python 3 introduces a ton of problems and doesn't really solve many."</span></span></div>
+</div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnDividerBlockOuter">
+        <tr>
+            <td class="mcnDividerBlockInner" style="min-width: 100%;padding: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                <table class="mcnDividerContent" border="0" cellpadding="0" cellspacing="0" width="100%" style="min-width: 100%;border-top: 3px solid #000000;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody><tr>
+                        <td style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                            <span></span>
+                        </td>
+                    </tr>
+                </tbody></table>
+<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+                        
+                            <div><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:18px"><u><a href="https://blog.logrocket.com/is-typescript-worth-it/" target="_blank" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: none;"><strong>Is TypeScript Worth It?</strong></a></u></span><br>
+<span style="font-size:16px">- Paul Cowan</span></span></div>
+
+<div>
+<div style="text-align: right;"><em><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:14px">#TypeScript&nbsp;</span></span></em></div>
+
+<div>&nbsp;</div>
+
+<div><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><span style="font-size:14px"><u><strong>tl;dr</strong></u>: "TypeScript offers above basic type checking, but soundness and runtime type checking are not goals, and this leaves TypeScript in an unfortunate halfway house with one foot in a better world and one where we currently are."&nbsp;</span></span></div>
+</div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-family: Helvetica;font-size: 15px;line-height: 150%;text-align: left;">
+                        
+                            
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnButtonBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnButtonBlockOuter">
+        <tr>
+            <td style="padding-top: 0;padding-right: 18px;padding-bottom: 18px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" valign="top" align="center" class="mcnButtonBlockInner">
+                <table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnButtonContentContainer" style="border-collapse: separate !important;border-radius: 0px;background-color: #000000;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                    <tbody>
+                        <tr>
+                            <td align="center" valign="middle" class="mcnButtonContent" style="font-family: &quot;Courier New&quot;, Courier, &quot;Lucida Sans Typewriter&quot;, &quot;Lucida Typewriter&quot;, monospace;font-size: 12px;padding: 10px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                                <a class="mcnButton " title="Pointer.io" href="http://www.pointer.io" target="_blank" style="font-weight: bold;letter-spacing: normal;line-height: 100%;text-align: center;text-decoration: none;color: #FFFFFF;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;display: block;">Pointer.io</a>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+    </tbody>
+</table></td>
+                                        </tr>
+                                    </table>
+                                    <!-- // END BODY -->
+                                </td>
+                            </tr>
+                            <tr>
+                                <td align="left" valign="top" style="mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+                                    <!-- BEGIN FOOTER // -->
+                                    <table border="0" cellpadding="0" cellspacing="0" width="600" id="templateFooter" style="border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;min-width: 100%;border-top: 0;">
+                                        <tr>
+                                            <td valign="top" class="footerContainer" style="padding-top: 9px;padding-bottom: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;"><table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock" style="min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+    <tbody class="mcnTextBlockOuter">
+        <tr>
+            <td valign="top" class="mcnTextBlockInner" style="padding-top: 9px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;">
+              	<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+			    
+				<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+                <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width: 100%;min-width: 100%;border-collapse: collapse;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;" width="100%" class="mcnTextContentContainer">
+                    <tbody><tr>
+                        
+                        <td valign="top" class="mcnTextContent" style="padding-top: 0;padding-right: 18px;padding-bottom: 9px;padding-left: 18px;mso-table-lspace: 0pt;mso-table-rspace: 0pt;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-family: Helvetica;font-size: 11px;line-height: 125%;text-align: left;">
+                        
+                            <div style="text-align: center;"><span style="font-family:courier new,courier,lucida sans typewriter,lucida typewriter,monospace"><a class="utilityLink" href="https://pointer.us9.list-manage.com/unsubscribe?u=e9492ff27d760c578a39d0675&id=6ba2b83261&e=[UNIQID]&c=ee9c973edf" style="line-height: 1.6em;-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;color: #202020;font-weight: normal;text-decoration: underline;">unsubscribe from this list</a><span style="line-height:1.6em">&nbsp;</span></span></div>
+
+                        </td>
+                    </tr>
+                </tbody></table>
+				<!--[if mso]>
+				</td>
+				<![endif]-->
+                
+				<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+            </td>
+        </tr>
+    </tbody>
+</table></td>
+                                        </tr>
+                                    </table>
+                                    <!-- // END FOOTER -->
+                                </td>
+                            </tr>
+                        </table>
+                        <!-- // END TEMPLATE -->
+                    </td>
+                </tr>
+            </table>
+        </center>
+    </body>
+</html>
+</div>
+	</div>
+</div>
+
+
+    
+    
+  </body>
+</html>

--- a/tests/fixtures/post_37528c1f-7f9d-43b2-aff4-989d860adb3f.html
+++ b/tests/fixtures/post_37528c1f-7f9d-43b2-aff4-989d860adb3f.html
@@ -1,0 +1,376 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Essential Reading For Engineering Leaders. Handpicked articles summarized into a 5‑minute read.">
+    <meta name="author" content="Suraj Kapoor">
+
+    <meta property="og:title" content="Essential Reading For Engineering Leaders"/>
+    <meta property="og:image" content="http://www.pointer.io/static/images/social-og.png"/>
+    <meta property="og:description" content="Handpicked articles summarized into a 5‑minute read."/>
+    <meta property="og:url" content="www.pointer.io"/>
+
+    <title>Pointer | Essential Reading For Engineering Leaders</title>
+
+    <link href="/static/css/main.css" rel="stylesheet">
+
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/static/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/static/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/static/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/static/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/static/safari-pinned-tab.svg"
+      color="#101720"
+    />
+    <meta name="msapplication-TileColor" content="#101720" />
+    <meta name="theme-color" content="#f3f4f6" />
+    
+    <script>
+	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+	  ga('create', 'UA-54273473-3', 'auto');
+	  ga('send', 'pageview');
+   </script>
+
+<!-- Google tag (gtag.js) -->
+   <script async src="https://www.googletagmanager.com/gtag/js?id=G-4MC7M40CEQ"></script>
+   <script>
+   window.dataLayer = window.dataLayer || [];
+   function gtag(){dataLayer.push(arguments);}
+   gtag('js', new Date());
+
+   gtag('config', 'G-4MC7M40CEQ');
+   </script>
+
+    <script>
+      !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+      posthog.init('phc_4ok8ZC2gD3gA0aIQ0jYS4RliamTWKPVuL4kNsmbQX94',{api_host:'https://us.i.posthog.com'})
+    </script>
+
+
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P9R9NX9');</script>
+  <!-- End Google Tag Manager -->
+
+
+  <!-- Facebook Pixel Code -->
+  <script>
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '6476529382457682');
+  fbq('track', 'PageView');
+  </script>
+  <noscript><img height="1" width="1" style="display:none"
+  src="https://www.facebook.com/tr?id=6476529382457682&ev=PageView&noscript=1"
+  /></noscript>
+  <!-- End Facebook Pixel Code -->
+
+  <!-- Reddit Pixel --><script>!function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);rdt('init','t2_einsuv7w');rdt('track', 'PageVisit');</script><!-- DO NOT MODIFY --><!-- End Reddit Pixel -->
+  
+  </head>
+  <body class="flex flex-col bg-blue-950 font-grotesk text-gray-200">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P9R9NX9" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
+    <header class="bg-blue-950">
+      <nav
+        class="mx-auto flex items-center justify-between px-6 py-4 lg:px-8"
+        aria-label="Global"
+      >
+        <a href="/" class="-m-1.5 p-1.5 text-inherit">
+          <svg
+            clip-rule="evenodd"
+            fill-rule="evenodd"
+            stroke-linejoin="round"
+            stroke-miterlimit="2"
+            viewBox="0 0 334 69"
+            xmlns="http://www.w3.org/2000/svg"
+            class="max-h-full w-32 fill-gray-100"
+          >
+            <path
+              d="m425.633 1384.78-27.63-27.63-12.49-28.01-6.056 2.65 10.597 27.63v40.12h-36.335v-40.12l10.598-27.63-6.056-2.65-12.49 28.01-27.63 27.63-25.359-25.36 27.63-27.63 28.008-12.49-2.649-6.05-27.63 10.59h-40.121v-36.33h40.121l27.63 10.6 2.649-6.06-28.008-12.49-27.63-27.63 25.359-25.36 27.63 27.63 12.49 28.01 6.056-2.65-10.598-27.63v-40.12h36.335v40.12l-10.597 27.63 6.056 2.65 12.49-28.01 27.63-27.63 25.359 25.36-27.63 27.63-28.009 12.49 2.65 6.06 27.63-10.6h40.12v36.33h-40.12l-27.63-10.59-2.65 6.05 28.009 12.49 27.63 27.63z"
+              fill-rule="nonzero"
+              transform="matrix(.119681 0 0 .119681 71.822 -145.03)"
+            />
+            <g
+              transform="matrix(.210802 0 0 .210802 -157.384 -236.08)"
+            >
+              <path
+                d="m796.556 1338.23v99.92h-49.961v-264.95h103.707c13.626 0 25.485 2.21 35.578 6.63 10.094 4.41 18.484 10.22 25.17 17.41 6.687 7.19 11.734 15.39 15.14 24.6s5.11 18.61 5.11 28.2v9.08c0 9.84-1.704 19.49-5.11 28.96-3.406 9.46-8.453 17.91-15.14 25.35-6.686 7.45-15.076 13.44-25.17 17.98-10.093 4.54-21.952 6.82-35.578 6.82zm0-47.69h48.826c11.102 0 19.871-3.03 26.305-9.09 6.434-6.05 9.652-13.88 9.652-23.46v-4.55c0-9.58-3.218-17.41-9.652-23.46-6.434-6.06-15.203-9.09-26.305-9.09h-48.826z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1164.45 1346.55c0 15.65-2.65 29.46-7.95 41.45-5.3 11.98-12.49 22.08-21.57 30.28s-19.49 14.44-31.23 18.73c-11.73 4.29-24.03 6.44-36.9 6.44s-25.17-2.15-36.9-6.44c-11.74-4.29-22.15-10.53-31.229-18.73-9.083-8.2-16.275-18.3-21.574-30.28-5.299-11.99-7.948-25.8-7.948-41.45v-4.54c0-15.39 2.649-29.08 7.948-41.07 5.299-11.98 12.491-22.14 21.574-30.46 9.079-8.33 19.489-14.64 31.229-18.93 11.73-4.29 24.03-6.43 36.9-6.43s25.17 2.14 36.9 6.43c11.74 4.29 22.15 10.6 31.23 18.93 9.08 8.32 16.27 18.48 21.57 30.46 5.3 11.99 7.95 25.68 7.95 41.07zm-97.65 51.48c6.81 0 13.25-1.14 19.3-3.41 6.06-2.27 11.36-5.55 15.9-9.84s8.14-9.52 10.79-15.71c2.65-6.18 3.97-13.18 3.97-21v-7.57c0-7.83-1.32-14.83-3.97-21.01s-6.25-11.42-10.79-15.71-9.84-7.57-15.9-9.84c-6.05-2.27-12.49-3.4-19.3-3.4s-13.25 1.13-19.3 3.4c-6.06 2.27-11.36 5.55-15.9 9.84s-8.14 9.53-10.79 15.71-3.97 13.18-3.97 21.01v7.57c0 7.82 1.32 14.82 3.97 21 2.65 6.19 6.25 11.42 10.79 15.71s9.84 7.57 15.9 9.84c6.05 2.27 12.49 3.41 19.3 3.41z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1215.55 1392.73h63.58v-96.89h-59.04v-45.43h106.74v142.32h54.5v45.42h-165.78z"
+              />
+              <path
+                d="m1491.47 1438.15h-47.69v-187.74h47.69v28.01h6.81c4.29-10.59 11.23-18.8 20.82-24.6s20.82-8.7 33.69-8.7c9.08 0 17.59 1.45 25.54 4.35s14.95 7.38 21.01 13.44c6.06 6.05 10.79 13.75 14.19 23.08 3.41 9.34 5.11 20.44 5.11 33.31v118.85h-47.69v-106.74c0-13.37-3.21-23.9-9.65-31.6-6.43-7.7-15.71-11.54-27.82-11.54-14.13 0-24.66 4.73-31.6 14.19s-10.41 22.14-10.41 38.04z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1670.12 1250.41h55.64v-77.21h47.69v77.21h67.75v45.43h-67.75v85.53c0 7.57 3.4 11.36 10.22 11.36h50.71v45.42h-79.48c-8.58 0-15.58-2.78-21.01-8.33-5.42-5.55-8.13-12.62-8.13-21.2v-112.78h-55.64z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1949.07 1359.8c.25 5.55 1.57 10.66 3.97 15.33s5.68 8.7 9.84 12.11c4.17 3.41 8.96 6.06 14.39 7.95 5.42 1.89 11.16 2.84 17.22 2.84 11.86 0 20.94-2.08 27.25-6.25 6.31-4.16 10.85-9.14 13.62-14.95l40.88 22.71c-2.27 4.8-5.42 9.78-9.46 14.95s-9.27 9.91-15.71 14.2c-6.43 4.29-14.25 7.82-23.46 10.59-9.22 2.78-20 4.17-32.37 4.17-14.13 0-26.99-2.27-38.6-6.82-11.61-4.54-21.64-11.1-30.09-19.68-8.46-8.58-15.02-19.05-19.68-31.41-4.67-12.37-7.01-26.37-7.01-42.01v-2.28c0-14.38 2.46-27.5 7.38-39.36s11.67-21.95 20.25-30.28 18.61-14.82 30.09-19.49c11.49-4.67 23.79-7 36.91-7 16.15 0 30.02 2.83 41.63 8.51s21.2 12.87 28.77 21.58c7.57 8.7 13.12 18.29 16.65 28.76s5.3 20.63 5.3 30.47v25.36zm45.04-71.53c-12.11 0-21.95 3.09-29.52 9.27s-12.49 13.31-14.76 21.38h88.56c-1.51-8.83-6.24-16.15-14.19-21.95s-17.98-8.7-30.09-8.7z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m2129.61 1250.41h79.48v27.26h6.82c3.53-10.35 9.52-18.36 17.97-24.04 8.46-5.68 18.61-8.51 30.47-8.51 18.68 0 33.69 5.86 45.04 17.6 11.36 11.73 17.04 29.58 17.04 53.55v8.33l-49.21 4.54v-5.3c0-10.34-2.65-18.61-7.95-24.79s-13.24-9.27-23.84-9.27-18.93 3.66-24.98 10.98c-6.06 7.31-9.09 17.78-9.09 31.41v60.56h43.15v45.42h-129.44v-45.42h38.6v-96.89h-34.06z"
+                fill-rule="nonzero"
+              />
+            </g>
+          </svg>
+        </a>
+        <div class="flex gap-x-12">
+          
+        </div>
+      </nav>
+    </header>
+    
+
+<div class="bg-white">
+	<div class="w-[670px] max-w-full m-auto py-8">
+		<div class="pb-2 px-1">
+			<h1 class="m-0 text-2xl text-gray-950 font-bold">Issue #713</h1>
+			<time datetime="2026-05-05 08:00:00" class="mt-0 text-gray-500">May 5, 2026</time>
+			<div class="flex justify-between text-center py-2">
+				
+					<a href="/archives/post_85fbc799-0509-4ece-8ae3-c2644c3157bb" class="inline-block mt-3 w-1/4 flex-none rounded-md bg-yellow-300 px-3.5 py-3 text-sm font-bold text-gray-900 shadow-sm hover:bg-yellow-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-300">&laquo; Prev</a>
+				
+				
+					<a href="/archives/post_f8692b78-4c4e-4ed9-81fa-1d3ace0d0423" class="inline-block mt-3 w-1/4 flex-none rounded-md bg-yellow-300 px-3.5 py-3 text-sm font-bold text-gray-900 shadow-sm hover:bg-yellow-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-300">Next &raquo;</a>
+				
+			</div>
+		</div>
+		<div class="text-transparent"><!DOCTYPE html><html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" style="font-size:16px;"><head></head><head><meta charset="utf-8"/><!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"/><!--<![endif]--><meta name="viewport" content="width=device-width,initial-scale=1"/><meta name="x-apple-disable-message-reformatting"/><meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no"/><meta name="color-scheme" content="light"/><meta name="supported-color-schemes" content="light"/><title>Issue #713</title><base target="_blank"><!--[if mso]><xml><o:OfficeDocumentSettings><o:AllowPNG/><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml><![endif]--><style>
+  :root { color-scheme: light; supported-color-schemes: light; }
+  body { margin: 0; padding: 0; min-width: 100%!important; -ms-text-size-adjust: 100% !important; -webkit-transform: scale(1) !important; -webkit-text-size-adjust: 100% !important; -webkit-font-smoothing: antialiased !important; }
+  .body { word-wrap: normal; word-spacing:normal; }
+  table.mso { width: 100%; border-collapse: collapse; padding: 0; table-layout: fixed; }
+  img { border: 0; outline: none; }
+  table {  mso-table-lspace: 0px; mso-table-rspace: 0px; }
+  td, a, span {  mso-line-height-rule: exactly; }
+  #root [x-apple-data-detectors=true],
+  a[x-apple-data-detectors=true],
+  #MessageViewBody a { color: inherit !important; text-decoration: inherit !important; font-size: inherit !important; font-family: inherit !important; font-weight: inherit !important; line-height: inherit !important; }
+  span.MsoHyperlink { color: inherit !important; mso-style-priority: 99 !important; }
+  span.MsoHyperlinkFollowed { color: inherit !important; mso-style-priority: 99 !important; }
+  .a { background-color:#ffffff; }
+  .b { background-color:#111827; }
+  .c  { background-color:#ffffff; }
+  .d { background-color:#101720; }
+  .d2 { background-color:#FFFFFF; }
+  .d3 { background-color:#fbbf24; }
+  h1 a { text-decoration:underline;color:#000000 !important; }
+  h2 a { text-decoration:underline;color:#000000 !important; }
+  h3 a { text-decoration:underline;color:#000000 !important; }
+  h4 a { text-decoration:underline;color:#000000 !important; }
+  h5 a { text-decoration:underline;color:#000000 !important; }
+  h6 a { text-decoration:underline;color:#000000 !important; }
+  h1, h1 a, h2, h2 a, h3, h3 a, h4, h4 a, h5, h5 a, h6, h6 a, ul, li, ol, p, p a { margin: 0;padding: 0; }
+  h1 { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-weight:700;font-size:24px;color:#000000;line-height:1.25;padding-bottom:0px;padding-top:16px;mso-margin-top-alt:16px;mso-margin-bottom-alt:0px }
+  h2 { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-weight:700;font-size:22px;color:#000000;line-height:1.5;padding-bottom:16px;padding-top:16px;mso-margin-top-alt:16px;mso-margin-bottom-alt:16px }
+  h3 { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-weight:700;font-size:18px;color:#000000;line-height:1.25;padding-bottom:10px;padding-top:10px;mso-margin-top-alt:10px;mso-margin-bottom-alt:10px }
+  h4 { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-weight:700;font-size:16px;color:#000000;line-height:1.125;padding-bottom:8px;padding-top:8px;mso-margin-top-alt:8px;mso-margin-bottom-alt:8px }
+  h5 { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-weight:400;font-size:16px;color:#000000;line-height:1;padding-bottom:10px;padding-top:10px;mso-margin-top-alt:10px;mso-margin-bottom-alt:10px }
+  h6 { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-weight:400;font-size:12px;color:#000000;line-height:0.875;padding-bottom:10px;padding-top:10px;mso-margin-top-alt:10px;mso-margin-bottom-alt:10px }
+  p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-weight:400;color:#000000;font-size:16px;line-height:1.5;padding-bottom:10px;padding-top:10px;mso-margin-top-alt:10px;mso-margin-bottom-alt:10px; }
+  p a, .e a, ul a, li a, .h a, .h2 a, .h3 a { word-break:break-word;color:#000000 !important;text-decoration:underline;text-decoration-color:#808080; }
+  p a span, .e a span, ul a span, li a span { color: inherit }
+  p .bold { font-weight:bold;color:#000000; }
+  p span[style*="font-size"] { line-height: 1.6; }
+  .f p { font-size:12px;line-height:15px;color:#000000;padding:0; }
+  .f p a { color:#000000 !important; }
+  .g p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-size:12px;line-height:17px;font-weight:Normal;margin:0; }
+  .g p a  { text-decoration: none; }
+  .i p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;line-height:1.5;font-size:14px;color:#f3f4f6; }
+  .i p a { color:#f3f4f6 !important; }
+  .i2 p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;line-height:1.5;font-size:16px;color:#111827; }
+  .i2 p a { color:#111827 !important; }
+  .i3 p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;line-height:1.8;font-size:18px;color:#111827; }
+  .i3 p a { color:#111827 !important; }
+  .h p a { color:#ffffff !important; }
+  .h2 p a { color:#111827 !important; }
+  .h3 p a { color:#111827 !important; }
+  .f p a, .i p a, .i2 p a, .i3 p a, .h p a, .h2 p a, .h3 p a { text-decoration:underline; }
+  .j { border-top:1px Solid #e5e7eb; }
+  .k p { padding-left:15px;padding-bottom:0px;padding-top:6px;mso-margin-top-alt:6px;mso-margin-bottom-alt:0px;mso-margin-left-alt:15px; }
+  .o { background-color:#FFFFFFFF;border:1px solid #111827;border-radius:4px; }
+  .o p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;padding:0px;margin:0px; }
+  .l p,
+  .l p a, .l a { font-size:12px;line-height:17px;font-weight: bold;color:#020617;padding-bottom:6px;mso-margin-bottom-alt:6px;text-decoration:none; }
+  .m p,
+  .m p a { font-size:12px;line-height:17px;font-weight:400;color:#111827;padding-bottom:6px;mso-margin-bottom-alt:6px;text-decoration:none; }
+  .n p,
+  .n p a { font-size:12px;line-height:17px;font-weight:400;color:#111827;padding-bottom:6px;mso-margin-bottom-alt:6px;text-decoration:none; }
+  .p { background-color:#FFFFFF;max-width:520px;border:1px solid #E1E8ED;border:1px solid rgba(80, 80, 80, 0.3);border-radius:5px; }
+  .q { font-size:16px;font-family:Helvetica,Roboto,Calibri,sans-serif !important;border:1px solid #e1e8ed;border:1px solid rgba(80, 80, 80, 0.3);border-radius:10px;background-color:#FFFFFF; }
+  .q p { font-size:16px;font-family:system-ui,Helvetica,Roboto,Calibri,sans-serif !important;color:#222222;padding:4px 0; }
+  .r { border:1px solid #E1E8ED !important;border-radius:5px; }
+  .s p { font-size: 14px; line-height: 17px; font-weight: 400; color: #697882; text-decoration: none; }
+  .t p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-size:12px;line-height:1.5;font-weight:400;color:#000000;font-style:normal;padding:0px; }
+  .v { border-radius:4px;border:solid 4px #3c658d;background-color:#3c658d;font-family:'Space Grotesk',Helvetica,Arial,sans-serif;color:#f9fafb; }
+  .v a { text-decoration:none;display:block;color:#f9fafb; }
+  .w p { font-size:12px;line-height:15px;font-weight:400;color:#ffffff; }
+  .w p a { text-decoration: underline !important;color:#ffffff !important; }
+  ul { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;margin:0px 0px 0px 25px !important;padding:0px !important;color:#000000;line-height:24px;list-style-type:disc !important;font-size:16px; }
+  ul ul { list-style-type:circle !important; }
+  ul ul ul { list-style-type:square !important; }
+  ul ul ul ul { list-style-type:disc !important; }
+  ul ul ul ul ul { list-style-type:circle !important; }
+  ul ul ul ul ul ul { list-style-type:square !important; }
+  ul ul ul ul ul ul ul { list-style-type:disc !important; }
+  ul ul ul ul ul ul ul ul { list-style-type:circle !important; }
+  ul ul ul ul ul ul ul ul ul { list-style-type:square !important; }
+  ul > li { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;margin:5px 0px 0px 0px !important;padding: 0px 0px 0px 0px !important; color: #000000; }
+  .poll-choices > li { margin: 4px 0px 0px 0px !important; }
+  ol { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;margin: 0px 0px 0px 25px !important;padding:0px !important;color:#000000;line-height:24px;list-style:decimal;font-size:16px; }
+  ol > li { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;margin:5px 0px 0px 0px !important;padding: 0px 0px 0px 0px !important; color: #000000; }
+  li > p, li p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-size:16px;font-weight:normal;line-height:24px;padding:0px; }
+  .e h3,
+  .e p,
+  .e span { padding-bottom:0px;padding-top:0px;mso-margin-top-alt:0px;mso-margin-bottom-alt:0px; }
+  .e span,
+  .e li { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-size:16px;color:#000000;line-height:24px; }
+  .rec { font-family:  ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !important; }
+  .rec__button:hover { background-color: #f9fafb !important; }
+  .copyright a {color: inherit !important; text-decoration: none !important; font-size: inherit !important; font-family: inherit !important; font-weight: inherit !important; line-height: inherit !important;}
+  .txt_social p { padding: 0; word-break: break-all; }
+  .table, .table-c, .table-h { border: 2px solid #111827; }
+  .table-c { padding:4px; background-color:#ffffff; }
+  .table-c p { color: #111827; font-family:'Space Grotesk',Helvetica,Arial,sans-serif !important;overflow-wrap: break-word; }
+  .table-h { padding:4px; background-color:#ffffff; }
+  .table-h p { color: #111827; font-family:'Space Grotesk',Helvetica,Arial,sans-serif !important;overflow-wrap: break-word; }
+  @media only screen and (max-width:667px) {
+    .aa, .w100pc { width: 100% !important; }
+    .bb img { width: 100% !important; height: auto !important; max-width: none !important; }
+    .cc { padding: 0px 8px !important; }
+    .ee { padding-top:10px !important;padding-bottom:10px !important; }
+    .ff ul, .ff ol { margin: 0px 0px 0px 10px !important;padding: 0px !important; }
+    .ff li { margin:5px 0px 0px 10px !important; }
+    .r {height:140px !important;}
+    .s p { font-size:13px !important;line-height:15px !important; }
+    .mob-hide {display:none !important;}
+    .mob-show {display: block !important; width: auto !important; overflow: visible !important; float: none !important; max-height: inherit !important; line-height: inherit !important;}
+    .mob-stack {width:100% !important;display:block !important;}
+    .mob-w-full {width:100% !important;}
+    .mob-block {display:block !important;}
+    .embed-img {padding:0px 0px 12px 0px !important;}
+    .socialShare {padding-top:15px !important;}
+    .rec { padding-left:15px!important;padding-right:15px!important; }
+    .bodyWrapper { padding:10px 4px 10px 4px !important; }
+    .social-mobile {float:left !important;margin-top:10px !important;}
+  }
+  @media screen and (max-width: 480px) {
+    u + .a .gg { width: 100% !important; width: 100vw !important; }
+    .tok-heart { padding-top:75% !important; }
+    .tok-play { padding-top: 250px !important; }
+  }
+  @media screen and (max-width: 320px) {
+    .tok-heart { padding-top:65% !important; }
+  }
+    
+
+* {
+  font-family: 'Space Grotesk', 'Space Mono', system-ui, Inter, Roboto, 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', Arial, sans-serif !important;
+}
+
+h1, h2, h3, h4, h5, h6, h1 *, h2 *, h3 *, h4 *, h5 *, h6 * {
+  font-family: 'Space Mono', 'Space Grotesk', ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace !important;
+}
+
+.dd > table a > img {
+  overflow: hidden;
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+}
+
+table p a {
+  text-decoration-color: currentcolor !important;
+}
+
+table h1 a[href][href], table h2 a[href][href], table h3 a[href][href] {
+  color: #000 !important;
+}
+
+a {
+  color: #000 !important;
+}
+  .u { border: 1px solid #CACACA !important; border-radius: 2px !important; background-color: #ffffff !important; padding: 0px 13px 0px 13px !important; font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif !important;font-size: 12px !important; color: #767676 !important; }
+  .u a { text-decoration: none; display: block !important; color: #767676 !important; margin: 0px !important; }
+  .u span, .u img { color: #767676 !important;margin:0px !important; max-height:32px !important;background-color:#ffffff !important; }
+</style><!--[if mso]><style type="text/css">
+    h1, h2, h3, h4, h5, h6 {font-family: Arial, sans-serif !important;}
+    body, table, td, p, a, span {font-family: Arial, sans-serif !important;}
+    sup { font-size: 100% !important;vertical-align: .5em !important;mso-text-raise: -1.5% !important;line-height: 0 !important; }
+    ul { margin-left:0px !important; margin-right:10px !important; margin-top:20px !important; margin-bottom:20px !important; }
+    ul li { margin-left: 0px !important; mso-special-format: decimal; }
+    ol { margin-left:0px !important; margin-right:10px !important; margin-top:20px !important; margin-bottom:20px !important; }
+    ol li { margin-left: 0px !important; mso-special-format: decimal; }
+    li.listItem { margin-left:15px !important; margin-top:0px !important; }
+    .paddingDesktop { padding: 10px 0 !important; }
+    .edm_outlooklist { margin-left: -20px !important; }
+    .embedImage { display:none !important; }
+</style><![endif]--><!-- __merge_tags_in_links__ --><style>
+        @font-face {
+          font-family: 'Space Grotesk';
+          font-style: normal;
+          font-weight: 700;
+          font-display: swap;
+          src: url('https://fonts.gstatic.com/s/spacegrotesk/v16/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj4PVnskPMBBSSJLm2E.woff2') format('woff2');
+        }
+
+        @font-face {
+          font-family: 'Space Grotesk';
+          font-style: normal;
+          font-weight: 400;
+          font-display: swap;
+          src: url('https://fonts.gstatic.com/s/spacegrotesk/v16/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj7oUXskPMBBSSJLm2E.woff2') format('woff2');
+        }
+
+</style></head><body class="a" style="margin:0px auto;padding:0px;word-wrap:normal;word-spacing:normal;background-color:#ffffff;"><div role="article" aria-roledescription="email" aria-label="email_name" lang="en" style="font-size:1rem"><div style="display:none;max-height:0px;overflow:hidden;"> Essential Reading For Engineering Leaders &#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204; </div><table role="none" width="100%" border="0" cellspacing="0" align="center" cellpadding="0" class="gg"><tr><td align="center" valign="top"><table role="none" width="670" border="0" cellspacing="0" cellpadding="0" class="aa" style="width:670px;table-layout:fixed;"><tr><td class="bodyWrapper" align="center" valign="top" style="padding:10px 0px 10px 0px;"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td align="center" valign="top" style="border-width:0px 0px 0px 0px;border-style: solid; border-color: #000000;border-radius:10px 10px 0px 0px;background-color:#ffffff;" class="c"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr id="header"><td style="padding:10px 10px 0px 10px;"><div style="padding-top:0px;padding-right:0px;padding-bottom:20px;padding-left:0px;"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td class="f" align="Right" valign="top"><p> May 5th, 2026 &nbsp; | &nbsp; <a data-read-online-tooltip="true" href="https://pointerio.beehiiv.com/p/issue-713?_bhlid=3f34f8914aa7a1dc441edfcff08e57620154e6fa">Read online</a></p></td></tr><tr><td class="dd" align="center" valign="top" style="width:100%;text-align:center;"><table role="none" border="0" cellspacing="0" cellpadding="0" align="center" style="margin:16px auto 16px; padding: 0;"><tbody><tr><td style="width:650px;padding: 0px 0px 0px 0px;text-align:center;"><a href="https://pointer.io?_bhlid=bab1d894f161216ba199d15a6404d1556fe0a3cd"><img alt="" width="650" height="auto" border="0" style="width:100%;height:auto;border:0;display:block;outline:none;text-decoration:none;margin:0 auto;" src="https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/0e19a781-9451-497c-8305-2d53c38ac0e6/Frame_10.png?t=1723724930"/></a></td></tr></tbody></table></td></tr></table></div></td></tr><tr id="content-blocks"><td class="email-card-body" align="center" valign="top" style="padding-bottom:px;"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td class="dd" align="center" style="padding:0px 10px;text-align:center;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> Tuesday 5th May’s issue is presented by Atono </p></td></tr><tr><td align="center" valign="top" style="padding-bottom:10px;padding-left:10px;padding-right:10px;padding-top:10px; " class="dd"><table role="none" border="0" cellspacing="0" cellpadding="0" style="margin:0 auto 0 auto;"><tr><td align="center" valign="top" style="width:455px;"><a href="https://atono.io/lp/context-gap-report?utm_campaign=274400984-2026%20%E2%80%93%20Asset%20%E2%80%93%20Context%20Gap%20Industry%20Report&utm_source=pointer_io_newsletter&utm_medium=sponsored_ad&utm_content=context_gap_report&aid=recTESLn3iI6Hr7sT&_bhlid=561c9a139950a220f0567060f37e1fa46c8d9a64" rel="noopener noreferrer nofollow" style="text-decoration:none;" target="_blank"><img src="https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/43b4116c-3f03-43e4-bd35-e3649f56b9ce/unnamed.png?t=1777923440" alt="" height="auto" width="455" style="display:block;width:100%;border-radius:0px 0px 0px 0px;border-style:solid;border-width:0px 0px 0px 0px;box-sizing:border-box;border-color:#E5E7EB;" border="0"/></a></td></tr></table></td></tr><tr><td id="what-350-engineers-revealed-about-a" class="dd" align="left" valign="top" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;"><h2 style="color:#000000;font-weight:Bold;mso-line-height-alt:150.0%;"><a class="link" href="https://atono.io/lp/context-gap-report?utm_campaign=274400984-2026%20%E2%80%93%20Asset%20%E2%80%93%20Context%20Gap%20Industry%20Report&utm_source=pointer_io_newsletter&utm_medium=sponsored_ad&utm_content=context_gap_report&aid=recabWKgk7TJLasPb&_bhlid=d7497fa74819a9db1729f1216f729221a9a7d2ab" target="_blank" rel="noopener noreferrer nofollow"><span>What 350 Engineers Revealed About AI Development Bottlenecks</span></a></h2></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> AI is accelerating development teams, but overall velocity hasn&#39;t really improved. The bottleneck isn&#39;t at the code layer. It&#39;s upstream, in the <a class="link" href="https://atono.io/lp/context-gap-report?utm_campaign=274400984-2026%20%E2%80%93%20Asset%20%E2%80%93%20Context%20Gap%20Industry%20Report&utm_source=pointer_io_newsletter&utm_medium=sponsored_ad&utm_content=context_gap_report&aid=recZCaNJDgmkJLyGT&_bhlid=b509ab3e74b2b4c6f266a910298a7487ea57850d" target="_blank" rel="noopener noreferrer nofollow"><span>gap between what product teams decide and what engineering teams actually receive</span></a>. </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> Atono&#39;s <a class="link" href="https://atono.io/lp/context-gap-report?utm_campaign=274400984-2026%20%E2%80%93%20Asset%20%E2%80%93%20Context%20Gap%20Industry%20Report&utm_source=pointer_io_newsletter&utm_medium=sponsored_ad&utm_content=context_gap_report&aid=recznB3pQBsPT1liL&_bhlid=3d71dd222984628d307eafd6afc58260b87f0d18" target="_blank" rel="noopener noreferrer nofollow"><span>Context Gap Industry Report</span></a> shares what they found when they asked 350 engineering professionals where AI product development actually breaks down. </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> Inside the report: </p></td></tr><tr><td style="padding-bottom:5px;padding-left:15px;padding-right:15px;padding-top:5px;" class="ee"><div style="margin-left:0px;" class="edm_outlooklist"><ul style="font-weight:normal;list-style-type:disc;margin-bottom:12px !important;margin-top:12px !important;padding:0px 0px 0px 0px;"><li class="listItem ultext"><p style="mso-line-height-alt:150.0%;padding:0px;text-align:left;word-break:break-word;"> Why 52% of teams have no shared AI context across developers </p></li><li class="listItem ultext"><p style="mso-line-height-alt:150.0%;padding:0px;text-align:left;word-break:break-word;"> How unclear requirements drive the majority of engineering rework </p></li><li class="listItem ultext"><p style="mso-line-height-alt:150.0%;padding:0px;text-align:left;word-break:break-word;"> Why AI at the implementation layer, without clarity at the planning layer, mostly accelerates rework </p></li><li class="listItem ultext"><p style="mso-line-height-alt:150.0%;padding:0px;text-align:left;word-break:break-word;"> What teams with the least rework are doing differently </p></li></ul></div></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> If you&#39;re leading engineering, this report shows you where the real leverage is. </p></td></tr><tr><td id="claim-your-075-apy-boost" class="dd" align="center" valign="top" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:center;"><h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;"><a class="link" href="https://atono.io/lp/context-gap-report?utm_campaign=274400984-2026%20%E2%80%93%20Asset%20%E2%80%93%20Context%20Gap%20Industry%20Report&utm_source=pointer_io_newsletter&utm_medium=sponsored_ad&utm_content=context_gap_report&aid=recBbkHZXRHlo4dHw&_bhlid=d4d1a4698b60e142c845d55488676dd83bb2d760" target="_blank" rel="noopener noreferrer nofollow"><span>Download The Free Report</span></a></h1></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="managing-up" class="dd" align="left" valign="top" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;"><a class="link" href="https://randsinrepose.com/archives/managing-up/?&aid=recDynfeQM5lW6ItW&aid=recaiy3bj93QJElYV&_bhlid=80376fa7e55b923106bf5b8ea585c9c76495b424" target="_blank" rel="noopener noreferrer nofollow"><span>Managing Up</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Michael Lopp </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: “In this piece, I will explain the projects, people, and political developments you always want to share - no matter what. While I will strive to make this complete, there is one type of development you must always report.” </p></td></tr><tr><td id="management-communication-managing-u" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>Management Communication ManagingUp</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="ask-for-advice-not-permission" class="dd" align="left" valign="top" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;"><a class="link" href="https://luminousmen.substack.com/p/be-the-idiot?aid=receSJ0PffNO6cVRJ&_bhlid=33dd4509b617603a9f675cb13e49c3fde670c112" target="_blank" rel="noopener noreferrer nofollow"><span>Be The Idiot</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Kirill Bobrov </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: “I’ve developed a mental checklist of “stupid” questions that have saved me more times than I can count.” The author shares some of these with the understanding that most engineering failures happen because someone was afraid to look stupid. </p></td></tr><tr><td id="leadership-management" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>Communication CareerGrowth</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="feature-riffing-how-ai-helps-p-ms-r" class="dd" align="left" valign="top" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;"><a class="link" href="https://atono.io/blog/feature-riffing-ai-refine-product-ideas-before-design?aid=recrNfMD0PMMl1JhL&_bhlid=d56ae17a4875818e1946a7dae11b9a21e0740a52" target="_blank" rel="noopener noreferrer nofollow"><span>Feature Riffing: How AI Helps PMs Refine Ideas Before Design</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: Better specs = fewer refinement cycles = faster shipping. Most acceptance criteria look solid on paper until engineering starts building. This post shows how product teams are using AI to validate feature logic through interactive mockups—surfacing edge cases and hierarchical complexity before specs reach your team. </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><i>Promoted by Atono</i></p></td></tr><tr><td id="ai-product" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i> AI Product</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="everything-you-need-to-know-about-o" class="dd" align="left" valign="top" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;"><a class="link" href="https://kimmalonescott.medium.com/fun-feedback-exercises-activities-to-do-with-your-team-67faacccb77c?aid=recPQdX1jVc2EFWyd&_bhlid=c5f01f138fd2dab4c46d471667a51d72c2514fb5" target="_blank" rel="noopener noreferrer nofollow"><span>Fun Feedback Exercises & Activities To Do With Your Team</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Kim Scott </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: “Engaging your team with fun feedback exercises can help create a culture of open communication and continuous improvement. Here are a few ideas you might find helpful.” </p></td></tr><tr><td id="leadership-management-career-growth" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i> Management Guide Feedback</i></span></h6></td></tr><tr><td align="center" valign="top" style="padding:30px 10px 30px 10px;" class="dd"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center" class="d" style="background-color:#101720;border-color:#ffffff;border-radius:10px 10px 10px 10px;border-style:solid;border-width:1px 1px 1px 1px;"><tr><td align="center" valign="top" style="padding:20px 20px 20px 20px;" class="dd"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td align="center" valign="top" class="i"><p style="color:#f3f4f6;font-weight:normal;margin:0px;text-align:center;">“If you hear a voice within you say, ‘You cannot paint,’ then by all means paint and that voice will be silenced.”</p></td></tr><tr><td height="14" style="line-height:1px;font-size:1px;height:14;">&nbsp;</td></tr><tr><td align="center" valign="top" class="h" style="color:#ffffff;font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-size:14px;font-weight:normal;padding-bottom:12px;padding-top:12px;"> — Vincent Van Gogh </td></tr></table></td></tr></table></td></tr><tr><td id="3-constraints-before-i-build-anythi" class="dd" align="left" valign="top" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;"><a class="link" href="https://jordanlord.co.uk/blog/3-constraints/?aid=rech8Jz6f2MZAYdxa&_bhlid=5f4befe58bd81af4ab8b9ff4254794504e4cdcab" target="_blank" rel="noopener noreferrer nofollow"><span>3 Constraints Before I Build Anything</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Jordan Lord </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: “I’ve been a builder for 10 years, and I&#39;ve built products that went nowhere because they were either too complex or had no identity. These are the constraints that I landed on after making those mistakes.”<span style="font-size:12px;"><i> </i></span></p></td></tr><tr><td id="ai-guide-best-practices" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>AI Guide BestPractices</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="to-make-sl-ms-think-bigger-orchestr" class="dd" align="left" valign="top" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;"><a class="link" href="https://fandf.co/4tiqz4S?aid=reclPsYQdBrLSfxoa&_bhlid=220f99f8a68893f3d93e00892f8887253385553c" target="_blank" rel="noopener noreferrer nofollow"><span>To Make SLMs Think Bigger, Orchestration Is The Key</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Nacho Martinez </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: Small language models often fail at multi-step reasoning, but agent-based architectures can bridge the gap. By layering search and control flow over LLM calls, the agent-reasoning framework adds 16 research-backed strategies to any Ollama model with zero code changes. </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><i>Promoted by Oracle</i></p></td></tr><tr><td id="ai-deep-dive-guide" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>AI DeepDive Guide</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="how-to-run-a-technical-due-diligenc" class="dd" align="left" valign="top" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;"><a class="link" href="https://makemeacto.substack.com/p/how-to-run-a-technical-due-diligence?aid=recSRVeC737tilDdV&_bhlid=271a2aa9ff7e89beab4e185d43e83f313465a332" target="_blank" rel="noopener noreferrer nofollow"><span>How to Run a Technical Due Diligence?</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Sergio Visinoni </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: A walkthrough of running a technical due diligence during M&A. Covers what the data room actually is, the four types of deals - brand acquisition, independent operation, full integration, acqui-hire - and what to prioritize in each - from security and compliance to talent assessment to data portability. </p></td></tr><tr><td id="ai-event" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>Leadership Guide Business</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="you-should-make-a-new-programming-l" class="dd" align="left" valign="top" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;"><a class="link" href="https://philpearl.github.io/post/swissing_a_table/?aid=recOvpZbA7cPVAWrc&_bhlid=de8d72cb3ba6745e8c010c6fa48c91ce8d44ad03" target="_blank" rel="noopener noreferrer nofollow"><span>Swissing A Table</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Philip Pearl </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: “This year I chose to investigate “Swiss tables”, the new hash table idea behind recent improvements to Go’s maps. Why am I interested in this? I’ve written a number of specialist hash tables, and I wondered if these approaches would lead to any performance improvements.” </p></td></tr><tr><td id="deep-dive-performance" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i> DeepDive Performance</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="the-ai-engineering-stack-we-built-i" class="dd" align="left" valign="top" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;"><a class="link" href="https://blog.cloudflare.com/internal-ai-engineering-stack/?aid=rec9mevXRn0xFN4du&_bhlid=240459f04a808077699e6a51f06da5755018e09e" target="_blank" rel="noopener noreferrer nofollow"><span>The AI Engineering Stack We Built Internally - On The Platform We Ship</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Rajesh Bhatia, Scott Roe-Meschke, Ayush Thakur </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: “Eleven months ago, we undertook a major project: to truly integrate AI into our engineering stack. We needed to build the internal MCP servers, access layer, and AI tooling necessary for agents to be useful at Cloudflare. We pulled together engineers from across the company to form a tiger team called iMARS (Internal MCP Agent/Server Rollout Squad). The sustained work landed with the Dev Productivity team, who also own much of our internal tooling including CI/CD, build systems, and automation.” </p></td></tr><tr><td id="developer-productivity-best-practic" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>AI Infrastructure CaseStudy</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="most-popular-from-last-issue" class="dd" align="left" valign="top" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;">Most Popular From Last Issue</h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b><a class="link" href="https://luminousmen.substack.com/p/drunk-post-things-ive-learned-as?aid=recB1tEgoOXzSQ5z1&_bhlid=eb7ae569da26087da2b02a83253aea6404c960f6" target="_blank" rel="noopener noreferrer nofollow"><span>Drunk Post: Things I’ve Learned As A Senior Engineer</span></a></b> -<b> </b>Kirill Bobrov </p></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="notable-links" class="dd" align="left" valign="top" style="color:#000000;font-weight:Bold;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:Bold;mso-line-height-alt:125.0%;">Notable Links</h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td id="code-burn-track-token-usage-cost-an" class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b><a class="link" href="https://github.com/getagentseal/codeburn?aid=recxPMLHKpZ23VjVV&_bhlid=eaf560db73625c67c132b670d1e8484e983054de" target="_blank" rel="noopener noreferrer nofollow"><span>CodeBurn</span></a></b>: Track token usage, cost, and performance. </p></td></tr><tr><td id="flue-agent-harness-framework" class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b><a class="link" href="https://github.com/withastro/flue?aid=recyA0O9u9TEQJ4Nm&_bhlid=04e40d905de48b8b8dbfb4196ab754209cb7a974" target="_blank" rel="noopener noreferrer nofollow"><span>Flue</span></a></b>: Agent harness framework. </p></td></tr><tr><td id="openhare-a-ipowered-crossplatform-d" class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b><a class="link" href="https://github.com/sjjian/openhare?aid=recKVEJgkjrE2dQF9&_bhlid=4cfa653e5675e2bf14f1347a2b41c85f72887686" target="_blank" rel="noopener noreferrer nofollow"><span>Openhare</span></a></b>: AI-powered, cross-platform desktop SQL client. </p></td></tr><tr><td id="space-agent-os-agent-that-builds-yo" class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b><a class="link" href="https://github.com/agent0ai/space-agent?aid=recVTnIwihmnEa9Ms&_bhlid=a72c63674a9cab042643f437ed88a9cf91332a03" target="_blank" rel="noopener noreferrer nofollow"><span>Space Agent</span></a></b>: OS agent that builds your space in the browser. </p></td></tr><tr><td id="super-plane-os-control-plane-for-pl" class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b><a class="link" href="https://github.com/superplanehq/superplane?aid=recxZ5rgT3P0sDglh&_bhlid=2a9d2790d5cc7d7856b5b1c30aee40d794f58d89" target="_blank" rel="noopener noreferrer nofollow"><span>SuperPlane</span></a></b>: OS control plane for platform engineering. </p></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td align="center" valign="top" class="e"><table role="none" border="0" cellspacing="0" cellpadding="0" align="left"><tr><td align="left" valign="top" style="padding:10px 10px 10px;"><h3 style="">How did you like this issue of Pointer? </h3><p style="">1 = Didn&#39;t enjoy it all // 5 = Really enjoyed it</p></td></tr><tr><td align="left" valign="top" style="padding:0px 10px 10px;"><span><a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=168ea9f2-7130-4ae4-8f04-7bf1bd8780ea&ppid=c84ccdcd-2327-4f80-98e1-604a37e58d41&sid=SUBSCRIBER_ID&_bhlid=8760cc8cee40d6e4b60fa86aee26007ad8416c32">1</a></span><span style=""> &nbsp;|&nbsp; </span><span><a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=9e524ac8-f554-4474-b06d-a0a1b5f9e2d5&ppid=c84ccdcd-2327-4f80-98e1-604a37e58d41&sid=SUBSCRIBER_ID&_bhlid=4b6686c67360b29e6d080c618a9eda99173d0c46">2</a></span><span style=""> &nbsp;|&nbsp; </span><span><a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=e3d1fc61-4c67-44ee-b815-e849def5a216&ppid=c84ccdcd-2327-4f80-98e1-604a37e58d41&sid=SUBSCRIBER_ID&_bhlid=5e385064e40521226e8ebd03f030c4a30b516261">3</a></span><span style=""> &nbsp;|&nbsp; </span><span><a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=9afc13ca-b323-464e-a674-b992143cc258&ppid=c84ccdcd-2327-4f80-98e1-604a37e58d41&sid=SUBSCRIBER_ID&_bhlid=e2e8306867202cc43542fafb4bc11dae56c14e28">4</a></span><span style=""> &nbsp;|&nbsp; </span><span><a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=36e7f97a-3a9e-4b58-95ab-b72e85cd83c3&ppid=c84ccdcd-2327-4f80-98e1-604a37e58d41&sid=SUBSCRIBER_ID&_bhlid=52ca5ce794169ee0210247c8edc4e26d1a8a9533">5</a></span></td></tr></table></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:30px 0px 30px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr></table></td></tr></table></td></tr><tr><td align="center" valign="top"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td><tr><td class="b" align="center" valign="top" bgcolor="#111827" style="padding:0px 0px 0px 0px;border-style:solid;border-width: 0px 0px 0px 0px;border-color: #000000;border-bottom-left-radius:10px;border-bottom-right-radius:10px;"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td height="10" style="line-height:1px;font-size:1px;height:10px;"> &nbsp; </td></tr><tr><td class="w" align="center" valign="top" style="padding:15px 15px 15px 15px;"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td align="center" valign="top"><p style="font-family:'Space Grotesk',Helvetica,Arial,sans-serif;color:#ffffff!important;"> Update your email preferences or unsubscribe <a class="link" href="https://pointerio.beehiiv.com/subscribe/SUBSCRIBER_ID/preferences?post_id=37528c1f-7f9d-43b2-aff4-989d860adb3f&last_resource_guid=Post%3A37528c1f-7f9d-43b2-aff4-989d860adb3f&_bhlid=c09ae596816e51ed25746f32a75c590a0b5d854c" style="text-decoration:underline;text-decoration-color:#ffffff!important;color:#ffffff!important;"> here</a></p><p class="copyright" style="font-family:'Space Grotesk',Helvetica,Arial,sans-serif;color:#ffffff!important;"> &copy; 2026 Pointer </p><p style="font-family:'Space Grotesk',Helvetica,Arial,sans-serif;color:#ffffff!important;"> 11 Hoyt Street, #35B<br>Brooklyn, New York 11201, United States </p></td></tr><tr><td align="left" valign="top" height="2" style="height:2px;"><a href='https://hp.beehiiv.com/SUBSCRIBER_ID' style="color: #111827 !important; cursor: default; font-size: 1px; text-decoration: none;"> Terms of Service </a></td></tr><tr><td align="left" valign="top" height="2" style="height:2px;"><a href='https://email.beehiivstatus.com/{{omnivery_honeypot_hash}}/hclick' clicktracking="off" style="color: #111827 !important; cursor: default; font-size: 1px; text-decoration: none;"></a></td></tr></table></td></tr></table></td></tr></td></tr></table></td></tr></table></td></tr></table></td></tr></table></div></body></html></div>
+	</div>
+</div>
+
+
+    
+    
+  </body>
+</html>

--- a/tests/fixtures/post_aa76678f-b955-4a29-927e-388a5e3410d4.html
+++ b/tests/fixtures/post_aa76678f-b955-4a29-927e-388a5e3410d4.html
@@ -1,0 +1,375 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Essential Reading For Engineering Leaders. Handpicked articles summarized into a 5‑minute read.">
+    <meta name="author" content="Suraj Kapoor">
+
+    <meta property="og:title" content="Essential Reading For Engineering Leaders"/>
+    <meta property="og:image" content="http://www.pointer.io/static/images/social-og.png"/>
+    <meta property="og:description" content="Handpicked articles summarized into a 5‑minute read."/>
+    <meta property="og:url" content="www.pointer.io"/>
+
+    <title>Pointer | Essential Reading For Engineering Leaders</title>
+
+    <link href="/static/css/main.css" rel="stylesheet">
+
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/static/apple-touch-icon.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="/static/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/static/favicon-16x16.png"
+    />
+    <link rel="manifest" href="/static/site.webmanifest" />
+    <link
+      rel="mask-icon"
+      href="/static/safari-pinned-tab.svg"
+      color="#101720"
+    />
+    <meta name="msapplication-TileColor" content="#101720" />
+    <meta name="theme-color" content="#f3f4f6" />
+    
+    <script>
+	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+	  ga('create', 'UA-54273473-3', 'auto');
+	  ga('send', 'pageview');
+   </script>
+
+<!-- Google tag (gtag.js) -->
+   <script async src="https://www.googletagmanager.com/gtag/js?id=G-4MC7M40CEQ"></script>
+   <script>
+   window.dataLayer = window.dataLayer || [];
+   function gtag(){dataLayer.push(arguments);}
+   gtag('js', new Date());
+
+   gtag('config', 'G-4MC7M40CEQ');
+   </script>
+
+    <script>
+      !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+      posthog.init('phc_4ok8ZC2gD3gA0aIQ0jYS4RliamTWKPVuL4kNsmbQX94',{api_host:'https://us.i.posthog.com'})
+    </script>
+
+
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P9R9NX9');</script>
+  <!-- End Google Tag Manager -->
+
+
+  <!-- Facebook Pixel Code -->
+  <script>
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '6476529382457682');
+  fbq('track', 'PageView');
+  </script>
+  <noscript><img height="1" width="1" style="display:none"
+  src="https://www.facebook.com/tr?id=370244158087974&ev=PageView&noscript=1"
+  /></noscript>
+  <!-- End Facebook Pixel Code -->
+
+  <!-- Reddit Pixel --><script>!function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];var t=d.createElement("script");t.src="https://www.redditstatic.com/ads/pixel.js",t.async=!0;var s=d.getElementsByTagName("script")[0];s.parentNode.insertBefore(t,s)}}(window,document);rdt('init','t2_einsuv7w');rdt('track', 'PageVisit');</script><!-- DO NOT MODIFY --><!-- End Reddit Pixel -->
+  
+  </head>
+  <body class="flex flex-col bg-blue-950 font-grotesk text-gray-200">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P9R9NX9" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
+    <header class="bg-blue-950">
+      <nav
+        class="mx-auto flex items-center justify-between border-b border-blue-900/50 px-6 py-4 shadow-sm lg:px-8"
+        aria-label="Global"
+      >
+        <a href="/" class="-m-1.5 p-1.5 text-inherit">
+          <svg
+            clip-rule="evenodd"
+            fill-rule="evenodd"
+            stroke-linejoin="round"
+            stroke-miterlimit="2"
+            viewBox="0 0 334 69"
+            xmlns="http://www.w3.org/2000/svg"
+            class="max-h-full w-32 fill-gray-100"
+          >
+            <path
+              d="m425.633 1384.78-27.63-27.63-12.49-28.01-6.056 2.65 10.597 27.63v40.12h-36.335v-40.12l10.598-27.63-6.056-2.65-12.49 28.01-27.63 27.63-25.359-25.36 27.63-27.63 28.008-12.49-2.649-6.05-27.63 10.59h-40.121v-36.33h40.121l27.63 10.6 2.649-6.06-28.008-12.49-27.63-27.63 25.359-25.36 27.63 27.63 12.49 28.01 6.056-2.65-10.598-27.63v-40.12h36.335v40.12l-10.597 27.63 6.056 2.65 12.49-28.01 27.63-27.63 25.359 25.36-27.63 27.63-28.009 12.49 2.65 6.06 27.63-10.6h40.12v36.33h-40.12l-27.63-10.59-2.65 6.05 28.009 12.49 27.63 27.63z"
+              fill-rule="nonzero"
+              transform="matrix(.119681 0 0 .119681 71.822 -145.03)"
+            />
+            <g
+              transform="matrix(.210802 0 0 .210802 -157.384 -236.08)"
+            >
+              <path
+                d="m796.556 1338.23v99.92h-49.961v-264.95h103.707c13.626 0 25.485 2.21 35.578 6.63 10.094 4.41 18.484 10.22 25.17 17.41 6.687 7.19 11.734 15.39 15.14 24.6s5.11 18.61 5.11 28.2v9.08c0 9.84-1.704 19.49-5.11 28.96-3.406 9.46-8.453 17.91-15.14 25.35-6.686 7.45-15.076 13.44-25.17 17.98-10.093 4.54-21.952 6.82-35.578 6.82zm0-47.69h48.826c11.102 0 19.871-3.03 26.305-9.09 6.434-6.05 9.652-13.88 9.652-23.46v-4.55c0-9.58-3.218-17.41-9.652-23.46-6.434-6.06-15.203-9.09-26.305-9.09h-48.826z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1164.45 1346.55c0 15.65-2.65 29.46-7.95 41.45-5.3 11.98-12.49 22.08-21.57 30.28s-19.49 14.44-31.23 18.73c-11.73 4.29-24.03 6.44-36.9 6.44s-25.17-2.15-36.9-6.44c-11.74-4.29-22.15-10.53-31.229-18.73-9.083-8.2-16.275-18.3-21.574-30.28-5.299-11.99-7.948-25.8-7.948-41.45v-4.54c0-15.39 2.649-29.08 7.948-41.07 5.299-11.98 12.491-22.14 21.574-30.46 9.079-8.33 19.489-14.64 31.229-18.93 11.73-4.29 24.03-6.43 36.9-6.43s25.17 2.14 36.9 6.43c11.74 4.29 22.15 10.6 31.23 18.93 9.08 8.32 16.27 18.48 21.57 30.46 5.3 11.99 7.95 25.68 7.95 41.07zm-97.65 51.48c6.81 0 13.25-1.14 19.3-3.41 6.06-2.27 11.36-5.55 15.9-9.84s8.14-9.52 10.79-15.71c2.65-6.18 3.97-13.18 3.97-21v-7.57c0-7.83-1.32-14.83-3.97-21.01s-6.25-11.42-10.79-15.71-9.84-7.57-15.9-9.84c-6.05-2.27-12.49-3.4-19.3-3.4s-13.25 1.13-19.3 3.4c-6.06 2.27-11.36 5.55-15.9 9.84s-8.14 9.53-10.79 15.71-3.97 13.18-3.97 21.01v7.57c0 7.82 1.32 14.82 3.97 21 2.65 6.19 6.25 11.42 10.79 15.71s9.84 7.57 15.9 9.84c6.05 2.27 12.49 3.41 19.3 3.41z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1215.55 1392.73h63.58v-96.89h-59.04v-45.43h106.74v142.32h54.5v45.42h-165.78z"
+              />
+              <path
+                d="m1491.47 1438.15h-47.69v-187.74h47.69v28.01h6.81c4.29-10.59 11.23-18.8 20.82-24.6s20.82-8.7 33.69-8.7c9.08 0 17.59 1.45 25.54 4.35s14.95 7.38 21.01 13.44c6.06 6.05 10.79 13.75 14.19 23.08 3.41 9.34 5.11 20.44 5.11 33.31v118.85h-47.69v-106.74c0-13.37-3.21-23.9-9.65-31.6-6.43-7.7-15.71-11.54-27.82-11.54-14.13 0-24.66 4.73-31.6 14.19s-10.41 22.14-10.41 38.04z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1670.12 1250.41h55.64v-77.21h47.69v77.21h67.75v45.43h-67.75v85.53c0 7.57 3.4 11.36 10.22 11.36h50.71v45.42h-79.48c-8.58 0-15.58-2.78-21.01-8.33-5.42-5.55-8.13-12.62-8.13-21.2v-112.78h-55.64z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m1949.07 1359.8c.25 5.55 1.57 10.66 3.97 15.33s5.68 8.7 9.84 12.11c4.17 3.41 8.96 6.06 14.39 7.95 5.42 1.89 11.16 2.84 17.22 2.84 11.86 0 20.94-2.08 27.25-6.25 6.31-4.16 10.85-9.14 13.62-14.95l40.88 22.71c-2.27 4.8-5.42 9.78-9.46 14.95s-9.27 9.91-15.71 14.2c-6.43 4.29-14.25 7.82-23.46 10.59-9.22 2.78-20 4.17-32.37 4.17-14.13 0-26.99-2.27-38.6-6.82-11.61-4.54-21.64-11.1-30.09-19.68-8.46-8.58-15.02-19.05-19.68-31.41-4.67-12.37-7.01-26.37-7.01-42.01v-2.28c0-14.38 2.46-27.5 7.38-39.36s11.67-21.95 20.25-30.28 18.61-14.82 30.09-19.49c11.49-4.67 23.79-7 36.91-7 16.15 0 30.02 2.83 41.63 8.51s21.2 12.87 28.77 21.58c7.57 8.7 13.12 18.29 16.65 28.76s5.3 20.63 5.3 30.47v25.36zm45.04-71.53c-12.11 0-21.95 3.09-29.52 9.27s-12.49 13.31-14.76 21.38h88.56c-1.51-8.83-6.24-16.15-14.19-21.95s-17.98-8.7-30.09-8.7z"
+                fill-rule="nonzero"
+              />
+              <path
+                d="m2129.61 1250.41h79.48v27.26h6.82c3.53-10.35 9.52-18.36 17.97-24.04 8.46-5.68 18.61-8.51 30.47-8.51 18.68 0 33.69 5.86 45.04 17.6 11.36 11.73 17.04 29.58 17.04 53.55v8.33l-49.21 4.54v-5.3c0-10.34-2.65-18.61-7.95-24.79s-13.24-9.27-23.84-9.27-18.93 3.66-24.98 10.98c-6.06 7.31-9.09 17.78-9.09 31.41v60.56h43.15v45.42h-129.44v-45.42h38.6v-96.89h-34.06z"
+                fill-rule="nonzero"
+              />
+            </g>
+          </svg>
+        </a>
+        <div class="flex gap-x-12">
+          
+        </div>
+      </nav>
+    </header>
+    
+
+<div class="bg-white">
+	<div class="w-[670px] max-w-full m-auto py-8">
+		<div class="pb-2 px-1">
+			<h1 class="m-0 text-2xl text-gray-950 font-bold">Issue #690</h1>
+			<time datetime="2026-02-13 09:00:14" class="mt-0 text-gray-500">February 13, 2026</time>
+			<div class="flex justify-between text-center py-2">
+				
+					<a href="/archives/post_887b1919-a654-4a90-810a-bf0f93ac90ca" class="inline-block mt-3 w-1/4 flex-none rounded-md bg-yellow-300 px-3.5 py-3 text-sm font-bold text-gray-900 shadow-sm hover:bg-yellow-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-300">&laquo; Prev</a>
+				
+				
+					<a href="/archives/post_906d4384-b737-46e2-bd2c-deda138cfc7a" class="inline-block mt-3 w-1/4 flex-none rounded-md bg-yellow-300 px-3.5 py-3 text-sm font-bold text-gray-900 shadow-sm hover:bg-yellow-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-300">Next &raquo;</a>
+				
+			</div>
+		</div>
+		<div class="text-transparent"><!DOCTYPE html><html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" style="font-size:16px;"><head></head><head><meta charset="utf-8"/><!--[if !mso]><!--><meta http-equiv="X-UA-Compatible" content="IE=edge"/><!--<![endif]--><meta name="viewport" content="width=device-width,initial-scale=1"/><meta name="x-apple-disable-message-reformatting"/><meta name="format-detection" content="telephone=no,address=no,email=no,date=no,url=no"/><meta name="color-scheme" content="light"/><meta name="supported-color-schemes" content="light"/><title>Issue #690</title><base target="_blank"><!--[if mso]><xml><o:OfficeDocumentSettings><o:AllowPNG/><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml><![endif]--><style>
+  :root { color-scheme: light; supported-color-schemes: light; }
+  body { margin: 0; padding: 0; min-width: 100%!important; -ms-text-size-adjust: 100% !important; -webkit-transform: scale(1) !important; -webkit-text-size-adjust: 100% !important; -webkit-font-smoothing: antialiased !important; }
+  .body { word-wrap: normal; word-spacing:normal; }
+  table.mso { width: 100%; border-collapse: collapse; padding: 0; table-layout: fixed; }
+  img { border: 0; outline: none; }
+  table {  mso-table-lspace: 0px; mso-table-rspace: 0px; }
+  td, a, span {  mso-line-height-rule: exactly; }
+  #root [x-apple-data-detectors=true],
+  a[x-apple-data-detectors=true],
+  #MessageViewBody a { color: inherit !important; text-decoration: inherit !important; font-size: inherit !important; font-family: inherit !important; font-weight: inherit !important; line-height: inherit !important; }
+  span.MsoHyperlink { color: inherit !important; mso-style-priority: 99 !important; }
+  span.MsoHyperlinkFollowed { color: inherit !important; mso-style-priority: 99 !important; }
+  .a { background-color:#ffffff; }
+  .b { background-color:#000000; }
+  .c  { background-color:#ffffff; }
+  .d { background-color:#000000; }
+  .d2 { background-color:#000000; }
+  .d3 { background-color:#000000; }
+  h1 a { text-decoration:underline;color:#000000 !important; }
+  h2 a { text-decoration:underline;color:#000000 !important; }
+  h3 a { text-decoration:underline;color:#000000 !important; }
+  h4 a { text-decoration:underline;color:#000000 !important; }
+  h5 a { text-decoration:underline;color:#000000 !important; }
+  h6 a { text-decoration:underline;color:#000000 !important; }
+  h1, h1 a, h2, h2 a, h3, h3 a, h4, h4 a, h5, h5 a, h6, h6 a, ul, li, ol, p, p a { margin: 0;padding: 0; }
+  h1 { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-weight:700;font-size:24px;color:#000000;line-height:1.75;padding-bottom:0px;padding-top:16px;mso-margin-top-alt:16px;mso-margin-bottom-alt:0px }
+  h2 { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-weight:700;font-size:22px;color:#000000;line-height:1.5;padding-bottom:16px;padding-top:16px;mso-margin-top-alt:16px;mso-margin-bottom-alt:16px }
+  h3 { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-weight:700;font-size:18px;color:#000000;line-height:1.25;padding-bottom:10px;padding-top:10px;mso-margin-top-alt:10px;mso-margin-bottom-alt:10px }
+  h4 { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-weight:700;font-size:16px;color:#000000;line-height:1.125;padding-bottom:8px;padding-top:8px;mso-margin-top-alt:8px;mso-margin-bottom-alt:8px }
+  h5 { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-weight:400;font-size:16px;color:#000000;line-height:1;padding-bottom:10px;padding-top:10px;mso-margin-top-alt:10px;mso-margin-bottom-alt:10px }
+  h6 { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-weight:400;font-size:12px;color:#000000;line-height:0.875;padding-bottom:10px;padding-top:10px;mso-margin-top-alt:10px;mso-margin-bottom-alt:10px }
+  p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-weight:400;color:#000000;font-size:16px;line-height:1.5;padding-bottom:10px;padding-top:10px;mso-margin-top-alt:10px;mso-margin-bottom-alt:10px; }
+  p a, .e a, ul a, li a, .h a, .h2 a, .h3 a { word-break:break-word;color:#000000 !important;text-decoration:underline;text-decoration-color:#808080; }
+  p a span, .e a span, ul a span, li a span { color: inherit }
+  p .bold { font-weight:bold;color:#000000; }
+  p span[style*="font-size"] { line-height: 1.6; }
+  .f p { font-size:12px;line-height:15px;color:#000000;padding:0; }
+  .f p a { color:#000000 !important; }
+  .g p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-size:12px;line-height:17px;font-weight:Normal;margin:0; }
+  .g p a  { text-decoration: underline; }
+  .i p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;line-height:1.5;font-size:14px;color:#f3f4f6; }
+  .i p a { color:#f3f4f6 !important; }
+  .i2 p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;line-height:1.5;font-size:16px;color:#111827; }
+  .i2 p a { color:#111827 !important; }
+  .i3 p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;line-height:1.8;font-size:18px;color:#111827; }
+  .i3 p a { color:#111827 !important; }
+  .h p a { color:#ffffff !important; }
+  .h2 p a { color:#111827 !important; }
+  .h3 p a { color:#111827 !important; }
+  .f p a, .i p a, .i2 p a, .i3 p a, .h p a, .h2 p a, .h3 p a { text-decoration:underline; }
+  .j { border-top:1px Solid #e5e7eb; }
+  .k p { padding-left:15px;padding-bottom:0px;padding-top:6px;mso-margin-top-alt:6px;mso-margin-bottom-alt:0px;mso-margin-left-alt:15px; }
+  .o { background-color:#000000;border:1px solid #111827;border-radius:4px; }
+  .o p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;padding:0px;margin:0px; }
+  .l p,
+  .l p a, .l a { font-size:12px;line-height:17px;font-weight: bold;color:#020617;padding-bottom:6px;mso-margin-bottom-alt:6px;text-decoration:none; }
+  .m p,
+  .m p a { font-size:12px;line-height:17px;font-weight:400;color:#111827;padding-bottom:6px;mso-margin-bottom-alt:6px;text-decoration:none; }
+  .n p,
+  .n p a { font-size:12px;line-height:17px;font-weight:400;color:#111827;padding-bottom:6px;mso-margin-bottom-alt:6px;text-decoration:none; }
+  .p { background-color:#FFFFFF;max-width:520px;border:1px solid #E1E8ED;border:1px solid rgba(80, 80, 80, 0.3);border-radius:5px; }
+  .q { font-size:16px;font-family:Helvetica,Roboto,Calibri,sans-serif !important;border:1px solid #e1e8ed;border:1px solid rgba(80, 80, 80, 0.3);border-radius:10px;background-color:#FFFFFF; }
+  .q p { font-size:16px;font-family:system-ui,Helvetica,Roboto,Calibri,sans-serif !important;color:#222222;padding:4px 0; }
+  .r { border:1px solid #E1E8ED !important;border-radius:5px; }
+  .s p { font-size: 14px; line-height: 17px; font-weight: 400; color: #697882; text-decoration: none; }
+  .t p { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-size:12px;line-height:1.5;font-weight:400;color:#000000;font-style:normal;padding:0px; }
+  .v { border-radius:4px;border:solid 4px #3c658d;background-color:#000000;font-family:'Space Grotesk',Helvetica,Arial,sans-serif;color:#f9fafb; }
+  .v a { text-decoration:none;display:block;color:#f9fafb; }
+  .w p { font-size:12px;line-height:15px;font-weight:400;color:#ffffff; }
+  .w p a { text-decoration: underline !important;color:#ffffff !important; }
+  ul { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;margin:0px 0px 0px 25px !important;padding:0px !important;color:#000000;line-height:24px;list-style-type:disc !important;font-size:16px; }
+  ul ul { list-style-type:circle !important; }
+  ul ul ul { list-style-type:square !important; }
+  ul ul ul ul { list-style-type:disc !important; }
+  ul ul ul ul ul { list-style-type:circle !important; }
+  ul ul ul ul ul ul { list-style-type:square !important; }
+  ul ul ul ul ul ul ul { list-style-type:disc !important; }
+  ul ul ul ul ul ul ul ul { list-style-type:circle !important; }
+  ul ul ul ul ul ul ul ul ul { list-style-type:square !important; }
+  ul > li { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;margin:5px 0px 0px 0px !important;padding: 0px 0px 0px 0px !important; color: #000000; }
+  ol { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;margin: 0px 0px 0px 25px !important;padding:0px !important;color:#000000;line-height:24px;list-style:decimal;font-size:16px; }
+  ol > li { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;margin:5px 0px 0px 0px !important;padding: 0px 0px 0px 0px !important; color: #000000; }
+  .e h3,
+  .e p,
+  .e span { padding-bottom:0px;padding-top:0px;mso-margin-top-alt:0px;mso-margin-bottom-alt:0px; }
+  .e span,
+  .e li { font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-size:16px;color:#000000;line-height:24px; }
+  .rec { font-family:  ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji" !important; }
+  .rec__button:hover { background-color: #f9fafb !important; }
+  .copyright a {color: inherit !important; text-decoration: none !important; font-size: inherit !important; font-family: inherit !important; font-weight: inherit !important; line-height: inherit !important;}
+  .txt_social p { padding: 0; word-break: break-all; }
+  .table, .table-c, .table-h { border: 2px solid #111827; }
+  .table-c { padding:4px; background-color:#000000; }
+  .table-c p { color: #111827; font-family:'Space Grotesk',Helvetica,Arial,sans-serif !important;overflow-wrap: break-word; }
+  .table-h { padding:4px; background-color:#000000; }
+  .table-h p { color: #111827; font-family:'Space Grotesk',Helvetica,Arial,sans-serif !important;overflow-wrap: break-word; }
+  @media only screen and (max-width:667px) {
+    .aa, .w100pc { width: 100% !important; }
+    .bb img { width: 100% !important; height: auto !important; max-width: none !important; }
+    .cc { padding: 0px 8px !important; }
+    .ee { padding-top:10px !important;padding-bottom:10px !important; }
+    .ff ul, .ff ol { margin: 0px 0px 0px 10px !important;padding: 0px !important; }
+    .ff li { margin:5px 0px 0px 10px !important; }
+    .r {height:140px !important;}
+    .s p { font-size:13px !important;line-height:15px !important; }
+    .mob-hide {display:none !important;}
+    .mob-show {display: block !important; width: auto !important; overflow: visible !important; float: none !important; max-height: inherit !important; line-height: inherit !important;}
+    .mob-stack {width:100% !important;display:block !important;}
+    .mob-w-full {width:100% !important;}
+    .mob-block {display:block !important;}
+    .embed-img {padding:0px 0px 12px 0px !important;}
+    .socialShare {padding-top:15px !important;}
+    .rec { padding-left:15px!important;padding-right:15px!important; }
+    .bodyWrapper { padding:10px 4px 10px 4px !important; }
+    .social-mobile {float:left !important;margin-top:10px !important;}
+  }
+  @media screen and (max-width: 480px) {
+    u + .a .gg { width: 100% !important; width: 100vw !important; }
+    .tok-heart { padding-top:75% !important; }
+    .tok-play { padding-top: 250px !important; }
+  }
+  @media screen and (max-width: 320px) {
+    .tok-heart { padding-top:65% !important; }
+  }
+    
+
+* {
+  font-family: 'Space Grotesk', 'Space Mono', system-ui, Inter, Roboto, 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', Arial, sans-serif !important;
+}
+
+h1, h2, h3, h4, h5, h6, h1 *, h2 *, h3 *, h4 *, h5 *, h6 * {
+  font-family: 'Space Mono', 'Space Grotesk', ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace !important;
+}
+
+.dd > table a > img {
+  overflow: hidden;
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+}
+
+table p a {
+  text-decoration-color: currentcolor !important;
+}
+
+table h1 a[href][href], table h2 a[href][href], table h3 a[href][href] {
+  color: #000 !important;
+}
+
+a {
+  color: #000 !important;
+}
+
+  .u { border: 1px solid #CACACA !important; border-radius: 2px !important; background-color: #ffffff !important; padding: 0px 13px 0px 13px !important; font-family:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans",sans-serif !important;font-size: 12px !important; color: #767676 !important; }
+  .u a { text-decoration: none; display: block !important; color: #767676 !important; margin: 0px !important; }
+  .u span, .u img { color: #767676 !important;margin:0px !important; max-height:32px !important;background-color:#ffffff !important; }
+</style><!--[if mso]><style type="text/css">
+    h1, h2, h3, h4, h5, h6 {font-family: Arial, sans-serif !important;}
+    body, table, td, p, a, span {font-family: Arial, sans-serif !important;}
+    sup { font-size: 100% !important;vertical-align: .5em !important;mso-text-raise: -1.5% !important;line-height: 0 !important; }
+    ul { margin-left:0px !important; margin-right:10px !important; margin-top:20px !important; margin-bottom:20px !important; }
+    ul li { margin-left: 0px !important; mso-special-format: decimal; }
+    ol { margin-left:0px !important; margin-right:10px !important; margin-top:20px !important; margin-bottom:20px !important; }
+    ol li { margin-left: 0px !important; mso-special-format: decimal; }
+    li.listItem { margin-left:15px !important; margin-top:0px !important; }
+    .paddingDesktop { padding: 10px 0 !important; }
+    .edm_outlooklist { margin-left: -20px !important; }
+    .embedImage { display:none !important; }
+</style><![endif]--><!-- __merge_tags_in_links__ --><style>
+        @font-face {
+          font-family: 'Space Grotesk';
+          font-style: normal;
+          font-weight: 700;
+          font-display: swap;
+          src: url('https://fonts.gstatic.com/s/spacegrotesk/v16/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj4PVnskPMBBSSJLm2E.woff2') format('woff2');
+        }
+
+        @font-face {
+          font-family: 'Space Grotesk';
+          font-style: normal;
+          font-weight: 400;
+          font-display: swap;
+          src: url('https://fonts.gstatic.com/s/spacegrotesk/v16/V8mQoQDjQSkFtoMM3T6r8E7mF71Q-gOoraIAEj7oUXskPMBBSSJLm2E.woff2') format('woff2');
+        }
+
+</style></head><body class="a" style="margin:0px auto;padding:0px;word-wrap:normal;word-spacing:normal;background-color:#ffffff;"><div role="article" aria-roledescription="email" aria-label="email_name" lang="en" style="font-size:1rem"><div style="display:none;max-height:0px;overflow:hidden;"> Essential Reading For Engineering Leaders &#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204;&#160;&#8204; </div><table role="none" width="100%" border="0" cellspacing="0" align="center" cellpadding="0" class="gg"><tr><td align="center" valign="top"><table role="none" width="670" border="0" cellspacing="0" cellpadding="0" class="aa" style="width:670px;table-layout:fixed;"><tr><td class="bodyWrapper" align="center" valign="top" style="padding:10px 0px 10px 0px;"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td align="center" valign="top" style="border-width:0px 0px 0px 0px;border-style: solid; border-color: #000000;border-radius:10px 10px 0px 0px;background-color:#ffffff;" class="c"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr id="header"><td style="padding:10px 10px 0px 10px;"><div style="padding-top:0px;padding-right:0px;padding-bottom:20px;padding-left:0px;"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td class="f" align="Right" valign="top"><p> February 13th, 2026 &nbsp; | &nbsp; <a href="https://pointerio.beehiiv.com/p/issue-690?_bhlid=b99228aaa2c513846a39f4f0989850a58c2d98d3"><span class="translation_missing" title="translation missing: en.templates.posts.email.header.read_online">Read Online</span></a></p></td></tr><tr><td class="dd" align="center" valign="top" style="width:100%;text-align:center;"><table role="none" border="0" cellspacing="0" cellpadding="0" align="center" style="margin:16px auto 16px; padding: 0;"><tbody><tr><td style="width:650px;padding: 0px 0px 0px 0px;text-align:center;"><a href="https://pointer.io?_bhlid=bab1d894f161216ba199d15a6404d1556fe0a3cd"><img alt="" width="650" height="auto" border="0" style="width:100%;height:auto;border:0;display:block;outline:none;text-decoration:none;margin:0 auto;" src="https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/0e19a781-9451-497c-8305-2d53c38ac0e6/Frame_10.png?t=1723724930"/></a></td></tr></tbody></table></td></tr></table></div></td></tr><tr id="content-blocks"><td class="email-card-body" align="center" valign="top" style="padding-bottom:px;"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td class="dd" align="center" style="padding:0px 10px;text-align:center;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> Friday 13th February issue is presented by WorkOS </p></td></tr><tr><td align="center" valign="top" style="padding-bottom:10px;padding-left:10px;padding-right:10px;padding-top:10px; " class="dd"><table role="none" border="0" cellspacing="0" cellpadding="0" style="margin:0 auto 0 auto;"><tr><td align="center" valign="top" style="width:195px;"><a href="https://workos.com/docs/pipes?utm_source=pointer&utm_medium=newsletter&utm_campaign=q12026&utm_content=no_rebuild?&aid=recSyhq06k0OeoDUJ&_bhlid=51c41cc318c6ad5c2cc0c43d18765a7b750fe64e" rel="noopener noreferrer nofollow" style="text-decoration:none;" target="_blank"><img src="https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/763c1dc8-c550-4a69-9385-104fe0aeb6d0/WorkOS__1_.png?t=1753778191" alt="" height="auto" width="195" style="display:block;width:100%;border-radius:0px 0px 0px 0px;border-style:solid;border-width:0px 0px 0px 0px;box-sizing:border-box;border-color:#E5E7EB;" border="0"/></a></td></tr></table></td></tr><tr><td id="ship-third-party-integrations-witho" class="dd" align="left" valign="top" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;"><h2 style="color:#000000;font-weight:700;mso-line-height-alt:150.0%;"><a class="link" href="https://workos.com/docs/pipes?utm_source=pointer&utm_medium=newsletter&utm_campaign=q12026&utm_content=no_rebuild?&aid=recJGbGeqR8ZnPiC5&_bhlid=fb7fbb5f5c619442efdd41991617e58b73fd3731" target="_blank" rel="noopener noreferrer nofollow"><span>Ship Third-Party Integrations Without Rebuilding OAuth</span></a></h2></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> Connecting user accounts to third-party APIs always comes with the same plumbing: OAuth flows, token storage, refresh logic, and provider-specific quirks. </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><a class="link" href="https://workos.com/blog/workos-pipes-third-party-integrations?utm_source=pointer&utm_medium=newsletter&utm_campaign=q12026&utm_content=product_name_link?&aid=recEfgdz1y2gLtWiT&_bhlid=385a7dff1380e81abd174c88609ed9d8452645a3" target="_blank" rel="noopener noreferrer nofollow"><span>WorkOS Pipes</span></a> removes that overhead. Users connect services like GitHub, Slack, Google, Salesforce, and other supported providers through a <a class="link" href="https://workos.com/docs/widgets/pipes?utm_source=pointer&utm_medium=newsletter&utm_campaign=q12026&utm_content=drop_in_widget?&aid=recrdqPUJY6k1RpLI&_bhlid=e97aebfd05621aff0b068450df95f5786ace7b3c" target="_blank" rel="noopener noreferrer nofollow"><span>drop-in widget</span></a>. Your backend requests a valid access token from the Pipes API when needed, while Pipes handles credential storage and token refresh. </p></td></tr><tr><td id="simplify-integrations-today" class="dd" align="center" valign="top" style="color:#000000;font-weight:700;padding:0px 10px;text-align:center;"><h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;"><a class="link" href="https://workos.com/docs/pipes?utm_source=pointer&utm_medium=newsletter&utm_campaign=q12026&utm_content=simplify_integrations_cta?&aid=recKykQXlK04yG7qO&_bhlid=b407ac96b8393b2bf4173035e26eb644a4bdb6af" target="_blank" rel="noopener noreferrer nofollow"><span>Simplify Integrations Today →</span></a></h1></td></tr><tr><td class="dd" align="center" style="padding:0px 10px;text-align:center;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="14-more-lessons-from-14-years-at-go" class="dd" align="left" valign="top" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;"><a class="link" href="https://addyo.substack.com/p/14-more-lessons-from-14-years-at?&aid=rec3nPcWZNDYBhlMU&_bhlid=45e01ce030eace56657272e9d0b154fd6c493406" target="_blank" rel="noopener noreferrer nofollow"><span>14 More Lessons From 14 Years At Google</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Addy Osmani </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: “Some of the hardest lessons I’ve learned aren’t about how you work. They’re about how teams work: how decisions actually get made, where coordination breaks down, what separates the groups that ship from the ones that spin. These lessons pick up where the first left off. They’re less about being a better individual engineer and more about the systems around the engineering.” </p></td></tr><tr><td id="career-advice" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>CareerAdvice</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="work-expands-time-vanishes-heres-wh" class="dd" align="left" valign="top" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;"><a class="link" href="https://read.perspectiveship.com/p/planning-laws?&aid=rechnXyVw6WZLA4iZ&_bhlid=0079d642f29f96fdc3af4014d11f489d69d18a35" target="_blank" rel="noopener noreferrer nofollow"><span>Work Expands. Time Vanishes. Here&#39;s Why.</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Michał Poczwardowski </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: “I’ve witnessed teams hiding real deadlines from each other. Afraid that if developers knew the real date, work would expand to fill it (Parkinson), while still taking longer than expected (Hofstadter). Some teams added multipliers to estimates, turning a 3-day estimate into 6 days automatically. This blurred what was being estimated in the first place.” </p></td></tr><tr><td id="leadership-management" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>Leadership Management</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="the-enterprise-infrastructure-behin" class="dd" align="left" valign="top" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;"><a class="link" href="https://workos.com/docs/pipes?utm_source=pointer&utm_medium=newsletter&utm_campaign=q12026&utm_content=secondary_title?&aid=recZZxBUPYcVTQ4hK&_bhlid=cf2ea41166788337ac7479fc41f90ba5c91ce51a" target="_blank" rel="noopener noreferrer nofollow"><span>The Enterprise Infrastructure Behind Successful AI Apps</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: Most AI apps fail to reach production not because of models, but because they lack enterprise infrastructure. This article breaks down the foundations teams need to scale AI responsibly, including identity, access control, auditability, and compliance. It shows how leading teams are building for production from day one. </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><i>Promoted by WorkOS</i></p></td></tr><tr><td id="leadership-management" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>Tools AI</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="most-popular-from-last-issue" class="dd" align="left" valign="top" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;"><a class="link" href="https://terriblesoftware.org/2026/02/02/why-am-i-doing-the-thinking-for-you/?&aid=recZr6iEnh1EkFxvw&_bhlid=72eab47e7717210b1758fa128549f10ec14e4287" target="_blank" rel="noopener noreferrer nofollow"><span>Why Am I Doing The Thinking For You?</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Matheus Lima </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: “That sounds harsh, but it’s true. When you ask someone “what do you think?” without sharing what you think, you’re not collaborating, but more like outsourcing? You’re taking all the work you should have done (reading and understanding the doc, weighing the trade-offs, forming an opinion) and dumping it on someone else’s lap. It looks like a question, but it’s more like a task assignment.” </p></td></tr><tr><td id="leadership-management" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>CareerAdvice</i></span></h6></td></tr><tr><td class="dd" align="right" style="padding:0px 10px;text-align:right;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td align="center" valign="top" style="padding:30px 10px 30px 10px;" class="dd"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center" class="d" style="background-color:#000000;border-color:#ffffff;border-radius:10px 10px 10px 10px;border-style:solid;border-width:0px 0px 0px 0px;"><tr><td align="center" valign="top" style="padding:20px 20px 20px 20px;" class="dd"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td align="center" valign="top" class="i"><p style="color:#f3f4f6;font-weight:400;margin:0px;text-align:center;"><i>“Life shrinks or expands in proportion to one’s courage.”</i></p></td></tr><tr><td height="14" style="line-height:1px;font-size:1px;height:14;">&nbsp;</td></tr><tr><td align="center" valign="top" class="h" style="color:#ffffff;font-family:'Space Grotesk',Helvetica,Arial,sans-serif;font-size:14px;font-weight:400;padding-bottom:12px;padding-top:12px;"> – Anais Nin </td></tr></table></td></tr></table></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td id="programming-aphorisms" class="dd" align="left" valign="top" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;"><a class="link" href="https://matklad.github.io/2026/02/11/programming-aphorisms.html?&aid=recQXzDPKHg3Vuiju&_bhlid=c7c4043c802ea207ef48e0a6d72f597b02b96747" target="_blank" rel="noopener noreferrer nofollow"><span>Programming Aphorisms</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Alex Kladov </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: “A meta programming post - looking at my thought process when coding and trying to pin down what is programming “knowledge”. Turns out, a significant fraction of that is just reducing new problems to a vocabulary of known tricks. This is a personal, descriptive post, not a prescriptive post for you.” </p></td></tr><tr><td id="thought-piece" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>ThoughtPiece</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="the-web-search-api-for-ai-apps-agen" class="dd" align="left" valign="top" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;"><a class="link" href="https://serpapi.com/blog/the-web-search-api-for-ai-applications/?utm_source=pointer?&aid=rece6f2vDLUIRlXCv&_bhlid=abb760a6c7f2963d7178e1ca0ff49a627315689e" target="_blank" rel="noopener noreferrer nofollow"><span>The Web Search API For AI Apps, Agents, And LLMs In 2026</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Hilman Ramadhan </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: Build AI apps without scraping headaches. Learn how a Web Search API extends model knowledge, delivers real-time data, and gives you full control and flexibility. </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><i>Promoted by SerpApi</i></p></td></tr><tr><td id="search-api-ai" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>Search API AI</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="how-to-make-architecture-decisions-" class="dd" align="left" valign="top" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;"><a class="link" href="https://lukasniessen.medium.com/how-to-make-architecture-decisions-rfcs-adrs-and-getting-everyone-aligned-ab82e5384d2f?&aid=recHPA1INpLPpkgsp&_bhlid=e3773013aea87be4570ba0867814cfc9b6947def" target="_blank" rel="noopener noreferrer nofollow"><span>How to Make Architecture Decisions: RFCs, ADRs, and Getting Everyone Aligned</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Lukas Niessen </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: “The thing is, architecture decisions are different from regular code decisions. They’re harder to reverse, they affect more people, and they often involve trade-offs that aren’t purely technical. You need buy-in. You need the right people in the room. And you need a process that doesn’t turn into endless meetings or bikeshedding. Here’s the approach I’ve found works well, both in my consulting work and in teams I’ve led.” </p></td></tr><tr><td id="architecture" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>Architecture</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="the-state-of-ai-in-2025-agents-inno" class="dd" align="left" valign="top" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;"><a class="link" href="https://martinalderson.com/posts/two-kinds-of-ai-users-are-emerging/?&aid=recfWlfS5aHz4eSFd&_bhlid=451ebb47c662b82cda0a2ffc7dbc28d9aba3e011" target="_blank" rel="noopener noreferrer nofollow"><span>Two Kinds Of AI Users Are Emerging. The Gap Between Them Is Astonishing.</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Martin Alderson </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: “It still shocks me how much difference there is between AI users. I think it explains a lot about the often confusing (to me) coverage in the media about AI and its productivity impact. I think it&#39;s clear there are two types of users to me now, and by extension, the organisations they work for.” </p></td></tr><tr><td id="management-leadership-ai" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>Management Leadership AI</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="using-an-engineering-notebook" class="dd" align="left" valign="top" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;"><h1 style="color:#000000;font-weight:700;mso-line-height-alt:175.0%;"><a class="link" href="https://ntietz.com/blog/using-an-engineering-notebook/?&aid=recuVzHf9454dpzAf&_bhlid=925a709b7796ed07f4211b4ad3105c5b203152cc" target="_blank" rel="noopener noreferrer nofollow"><span>Using An Engineering Notebook</span></a></h1></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"> — Nicole Tietz-Sokolskaya </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"></p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b>tl;dr</b>: “One of my core software engineering practices is writing, by hand, in a physical notebook. It&#39;s one of the most important things I do to remain productive and effective. Maybe the single most important. And it&#39;s a practice that I see very few others using!” </p></td></tr><tr><td id="ai" class="dd" align="right" valign="top" style="color:#000000;font-weight:Normal;padding:0px 10px;text-align:right;"><h6 style="color:#000000;font-weight:Normal;mso-line-height-alt:87.5%;"><span style="font-size:12px;"><i>CareerAdvice</i></span></h6></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="null-pointer" class="dd" align="left" valign="top" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;"><h2 style="color:#000000;font-weight:700;mso-line-height-alt:150.0%;">Null Pointer</h2></td></tr><tr><td align="center" valign="top" style="padding-bottom:10px;padding-left:10px;padding-right:10px;padding-top:10px; " class="dd"><table role="none" border="0" cellspacing="0" cellpadding="0" style="margin:0 auto 0 auto;"><tr><td align="center" valign="top" style="width:650px;"><img src="https://media.beehiiv.com/cdn-cgi/image/fit=scale-down,format=auto,onerror=redirect,quality=80/uploads/asset/file/92d5338d-8048-44c4-8b17-a61e7248dd5f/37_uber-legacy.png?t=1770919976" alt="" height="auto" width="650" style="display:block;width:100%;" border="0"/></td></tr><tr><td align="center" valign="top" class="t" style="width:650px; padding: 4px 0px 4px 0px;"><p>Uber-legacy</p></td></tr></table></td></tr><tr><td class="dd" align="center" style="padding:0px 10px;text-align:center;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><span style="font-size:0.8rem;">Hand-drawn by </span><span style="font-size:0.8rem;"><a class="link" href="https://ma.nu/graphics/?_bhlid=f2d7550f60843e76ba01517ee5122a261dcde023" target="_blank" rel="noopener noreferrer nofollow"><span>Manu</span></a></span><span style="font-size:0.8rem;">. Got an idea for a cartoon? Click reply and let us know</span></p></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="most-popular-from-last-issue" class="dd" align="left" valign="top" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;"><h2 style="color:#000000;font-weight:700;mso-line-height-alt:150.0%;">Most Popular From Last Issue</h2></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b><a class="link" href="https://justoffbyone.com/posts/how-to-run-11s?&aid=recQyHHDH5RYlCt9Z&_bhlid=4a3d6fea99515495a2d8d3f11607e66421acfa6c" target="_blank" rel="noopener noreferrer nofollow"><span>Running 1:1s For Engineers</span></a></b> -<b> </b>Can Duruk </p></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td id="notable-links" class="dd" align="left" valign="top" style="color:#000000;font-weight:700;padding:0px 10px;text-align:left;"><h2 style="color:#000000;font-weight:700;mso-line-height-alt:150.0%;">Notable Links</h2></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b><a class="link" href="https://github.com/homarr-labs/homarr?&aid=recuT8HJQQ5RBz9q8&_bhlid=9ce9c4c0b2abb2ccadeab6a01e5daadb34828c9e" target="_blank" rel="noopener noreferrer nofollow"><span>Homarr</span></a></b>:<b> </b>Modern and easy to use dashboard. </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b><a class="link" href="https://github.com/github/gh-aw?&aid=recdANtoaXFd7LA1T&_bhlid=d3f1c22b0bb2473b0d19c48cdfd2ae3f8cb15df8" target="_blank" rel="noopener noreferrer nofollow"><span>Gh-aw</span></a></b>:<b> </b>GitHub agentic workflows. </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b><a class="link" href="https://github.com/google/langextract?&aid=recXgjTEkRjVeqRui&_bhlid=81fe8a76c638bcdc99dd8e8bf433b655140e5fd8" target="_blank" rel="noopener noreferrer nofollow"><span>LangExtract</span></a></b>:<b> </b>Structured information from unstructured text. </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b><a class="link" href="https://github.com/tobi/qmd?&aid=recTjmo4UiyBe33Dn&_bhlid=6912507fcd751f71a666c2a14f0a0121f1e84c60" target="_blank" rel="noopener noreferrer nofollow"><span>QMD</span></a></b>:<b> </b>CLI search engine for your docs. </p></td></tr><tr><td class="dd" align="left" style="padding:0px 10px;text-align:left;word-break:break-word;"><p style="mso-line-height-alt:150.0%;"><b><a class="link" href="https://github.com/swark-io/swark?&aid=rec9fMAagMNdN1XVz&_bhlid=c24f27529a733442397cab7089769701c910d7e4" target="_blank" rel="noopener noreferrer nofollow"><span>Swark</span></a></b>:<b> </b>Create architecture diagrams from code automatically using LLMs. </p></td></tr><tr><td align="center" valign="top" style="font-size:0px;line-height:0px;padding:20px 0px 20px;" class="dd"><table class="j" role="none" width="96%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td> &nbsp; </td></tr></table></td></tr><tr><td style="padding:4px 10px"><br></td></tr><tr><td align="center" valign="top" class="e"><table role="none" border="0" cellspacing="0" cellpadding="0" align="left"><tr><td align="left" valign="top" style="padding:10px 10px 10px;"><h3 style="">How did you like this issue of Pointer? </h3><p style="">1 = Didn&#39;t enjoy it all // 5 = Really enjoyed it</p></td></tr><tr><td align="left" valign="top" style="padding:0px 10px 10px;"><span><a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=168ea9f2-7130-4ae4-8f04-7bf1bd8780ea&ppid=b8438e87-40c5-4839-b300-09d9b1a33f57&sid=SUBSCRIBER_ID&_bhlid=9bc793aebb4d0205249bfc7c698f130e94fe4f49">1</a></span><span style=""> &nbsp;|&nbsp; </span><span><a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=9e524ac8-f554-4474-b06d-a0a1b5f9e2d5&ppid=b8438e87-40c5-4839-b300-09d9b1a33f57&sid=SUBSCRIBER_ID&_bhlid=19cb354b114a05029c8cff40df5ea489b93f1918">2</a></span><span style=""> &nbsp;|&nbsp; </span><span><a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=e3d1fc61-4c67-44ee-b815-e849def5a216&ppid=b8438e87-40c5-4839-b300-09d9b1a33f57&sid=SUBSCRIBER_ID&_bhlid=ec4070a028cdc40d220c04e89279a35ee2c5c4ce">3</a></span><span style=""> &nbsp;|&nbsp; </span><span><a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=9afc13ca-b323-464e-a674-b992143cc258&ppid=b8438e87-40c5-4839-b300-09d9b1a33f57&sid=SUBSCRIBER_ID&_bhlid=8caa249ed389a7a25615adb35619610a3f692a1d">4</a></span><span style=""> &nbsp;|&nbsp; </span><span><a href="https://pointerio.beehiiv.com/polls/60180d23-3fbb-4689-974c-1db7f8617f77/response?pcid=36e7f97a-3a9e-4b58-95ab-b72e85cd83c3&ppid=b8438e87-40c5-4839-b300-09d9b1a33f57&sid=SUBSCRIBER_ID&_bhlid=ef24eb7574d1e4927cc1db202329efac51b95b19">5</a></span></td></tr></table></td></tr><tr><td style="padding:4px 10px"><br><br></td></tr></table></td></tr></table></td></tr><tr><td align="center" valign="top"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td><tr><td class="b" align="center" valign="top" bgcolor="#000000" style="padding:0px 0px 0px 0px;border-style:solid;border-width: 0px 0px 0px 0px;border-color: #000000;border-bottom-left-radius:10px;border-bottom-right-radius:10px;"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td height="10" style="line-height:1px;font-size:1px;height:10px;"> &nbsp; </td></tr><tr><td class="w" align="center" valign="top" style="padding:15px 15px 15px 15px;"><table role="none" width="100%" border="0" cellspacing="0" cellpadding="0" align="center"><tr><td align="center" valign="top"><p style="font-family:'Space Grotesk',Helvetica,Arial,sans-serif;color:#ffffff!important;"> Update your email preferences or unsubscribe <a class="link" href="https://pointerio.beehiiv.com/subscribe/SUBSCRIBER_ID/preferences?post_id=aa76678f-b955-4a29-927e-388a5e3410d4&last_resource_guid=Post%3Aaa76678f-b955-4a29-927e-388a5e3410d4&_bhlid=04b547257b60cd374a0d7ec36d3dd9f4acdf8d2d" style="text-decoration:underline;text-decoration-color:#ffffff!important;color:#ffffff!important;"> here</a></p><p class="copyright" style="font-family:'Space Grotesk',Helvetica,Arial,sans-serif;color:#ffffff!important;"> &copy; 2026 Pointer </p><p style="font-family:'Space Grotesk',Helvetica,Arial,sans-serif;color:#ffffff!important;"> 512 Rose Avenue, #224<br>Venice, California 90291, United States </p></td></tr><tr><td align="left" valign="top" height="2" style="height:2px;"><a href='https://hp.beehiiv.com/SUBSCRIBER_ID' style="color: #000000 !important; cursor: default; font-size: 1px; text-decoration: none;"> Terms of Service </a></td></tr><tr><td align="left" valign="top" height="2" style="height:2px;"><a href='https://email.beehiivstatus.com/{{omnivery_honeypot_hash}}/hclick' clicktracking="off" style="color: #000000 !important; cursor: default; font-size: 1px; text-decoration: none;"></a></td></tr></table></td></tr></table></td></tr></td></tr></table></td></tr></table></td></tr></table></td></tr></table></div></body></html></div>
+	</div>
+</div>
+
+
+    
+    
+  </body>
+</html>

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pathlib
+from typing import TYPE_CHECKING
+
+import bs4
+import pytest
+
+from pointer_io_rssfeed import cleanup
+
+if TYPE_CHECKING:
+    from syrupy.assertion import SnapshotAssertion
+
+_FIXTURE_DIR = pathlib.Path(__file__).parent / "fixtures"
+
+
+@pytest.mark.parametrize(
+    "fixture_path",
+    sorted(_FIXTURE_DIR.glob("*.html")),
+    ids=lambda p: p.name,
+)
+def test_html_to_description(fixture_path: pathlib.Path, snapshot: SnapshotAssertion) -> None:
+    html = fixture_path.read_text()
+    description = cleanup.html_to_description(html)
+    pretty = bs4.BeautifulSoup(description, features="html.parser").prettify()
+    assert pretty == snapshot

--- a/uv.lock
+++ b/uv.lock
@@ -172,6 +172,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -257,12 +266,30 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -280,7 +307,9 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pytest" },
     { name = "ruff" },
+    { name = "syrupy" },
     { name = "types-beautifulsoup4" },
 ]
 
@@ -296,7 +325,9 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy" },
+    { name = "pytest", specifier = ">=9.0.3" },
     { name = "ruff" },
+    { name = "syrupy", specifier = ">=5.2.0" },
     { name = "types-beautifulsoup4" },
 ]
 
@@ -307,6 +338,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -359,6 +415,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
+name = "syrupy"
+version = "5.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/7e/a4793801683d32132d9683be8364e93f6bca2f277bfbe81647eba46b8cfd/syrupy-5.2.0.tar.gz", hash = "sha256:0e6b7abf1e04f060f6c797bed8bca96f2468954168328041e02634a68fc11ff0", size = 50223, upload-time = "2026-05-16T21:11:37.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/18/dc99a152bea18a898a8ac387bfeb9ec0829e0f5bed11cfec2e2ca189c5a2/syrupy-5.2.0-py3-none-any.whl", hash = "sha256:798cb493a6e20f4839e58ea8f10eb1b0d85684c676442f79786e219bf32618e6", size = 51828, upload-time = "2026-05-16T21:11:34.984Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Extract _html_to_description into a new cleanup module (cleanup.html_to_description) and cover it with syrupy snapshot tests over real archive fixtures. Add pytest + syrupy dev deps plus pytest/ruff config.

Also fix pre-existing ruff (TC003) and mypy (sort-key) errors in rss.py and __init__.py that the test/lint setup surfaced.