### PR TITLE
Add CI workflow running ruff, mypy, and pytest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,38 @@
+name: "ci"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions: {}
+
+env:
+  FORCE_COLOR: 1
+  # prevent `uv run` from implicitly re-syncing the environment, which would
+  # reinstall the project in editable mode and defeat `uv sync --no-editable`
+  UV_NO_SYNC: 1
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+
+      # --no-editable tests against the built/installed package (not the
+      # source checkout) to catch packaging glitches (see also UV_NO_SYNC above)
+      - run: uv sync --no-editable --all-groups
+
+      - run: uv run ruff check
+
+      - run: uv run ruff format --check
+
+      - run: uv run mypy .
+
+      - run: uv run pytest


### PR DESCRIPTION
Extract _html_to_description into a new cleanup module
(cleanup.html_to_description) and cover it with syrupy snapshot tests
over real archive fixtures. Add pytest + syrupy dev deps plus
pytest/ruff config.

Also fix pre-existing ruff (TC003) and mypy (sort-key) errors in
rss.py and __init__.py that the test/lint setup surfaced.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>